### PR TITLE
Remove acronyms

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -189,7 +189,7 @@ func (ctx rsaEncrypterVerifier) encrypt(cek []byte, alg KeyAlgorithm) ([]byte, e
 }
 
 // Decrypt the given payload and return the content encryption key.
-func (ctx rsaDecrypterSigner) decryptKey(alg KeyAlgorithm, obj *JweObject, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
+func (ctx rsaDecrypterSigner) decryptKey(alg KeyAlgorithm, obj *JsonWebEncryption, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
 	return ctx.decrypt(recipient.encryptedKey, alg, generator)
 }
 
@@ -384,7 +384,7 @@ func (ctx ecKeyGenerator) genKey() ([]byte, map[string]interface{}, error) {
 }
 
 // Decrypt the given payload and return the content encryption key.
-func (ctx ecDecrypterSigner) decryptKey(alg KeyAlgorithm, obj *JweObject, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
+func (ctx ecDecrypterSigner) decryptKey(alg KeyAlgorithm, obj *JsonWebEncryption, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
 	var publicKey *ecdsa.PublicKey
 	epk, epkPresent := obj.getHeader("epk", recipient)
 	if epk, ok := epk.(map[string]interface{}); ok && epkPresent {

--- a/asymmetric_test.go
+++ b/asymmetric_test.go
@@ -257,7 +257,7 @@ func TestInvalidECDecrypt(t *testing.T) {
 	generator := randomKeyGenerator{size: 16}
 
 	// Missing epk header
-	obj := &JweObject{}
+	obj := &JsonWebEncryption{}
 
 	_, err := dec.decryptKey(ECDH_ES, obj, nil, generator)
 	if err == nil {

--- a/crypter.go
+++ b/crypter.go
@@ -25,22 +25,22 @@ import (
 
 // Encrypter represents an encrypter which produces an encrypted JWE object.
 type Encrypter interface {
-	Encrypt(plaintext []byte) (*JweObject, error)
-	EncryptWithAuthData(plaintext []byte, aad []byte) (*JweObject, error)
+	Encrypt(plaintext []byte) (*JsonWebEncryption, error)
+	EncryptWithAuthData(plaintext []byte, aad []byte) (*JsonWebEncryption, error)
 	SetCompression(alg CompressionAlgorithm)
 }
 
 // MultiEncrypter represents an encrypter which supports multiple recipients.
 type MultiEncrypter interface {
-	Encrypt(plaintext []byte) (*JweObject, error)
-	EncryptWithAuthData(plaintext []byte, aad []byte) (*JweObject, error)
+	Encrypt(plaintext []byte) (*JsonWebEncryption, error)
+	EncryptWithAuthData(plaintext []byte, aad []byte) (*JsonWebEncryption, error)
 	SetCompression(alg CompressionAlgorithm)
 	AddRecipient(alg KeyAlgorithm, encryptionKey interface{}) error
 }
 
 // Decrypter represents a decrypter which consumes an encrypted JWE object.
 type Decrypter interface {
-	Decrypt(object *JweObject) ([]byte, error)
+	Decrypt(object *JsonWebEncryption) ([]byte, error)
 }
 
 // A generic content cipher
@@ -63,7 +63,7 @@ type keyEncrypter interface {
 
 // A generic key decrypter
 type keyDecrypter interface {
-	decryptKey(alg KeyAlgorithm, obj *JweObject, recipient *recipientInfo, generator keyGenerator) ([]byte, error) // Decrypt a key
+	decryptKey(alg KeyAlgorithm, obj *JsonWebEncryption, recipient *recipientInfo, generator keyGenerator) ([]byte, error) // Decrypt a key
 }
 
 // A generic encrypter based on the given key encrypter and content cipher.
@@ -206,13 +206,13 @@ func NewDecrypter(decryptionKey interface{}) (Decrypter, error) {
 }
 
 // Implementation of encrypt method producing a JWE object.
-func (ctx *genericEncrypter) Encrypt(plaintext []byte) (*JweObject, error) {
+func (ctx *genericEncrypter) Encrypt(plaintext []byte) (*JsonWebEncryption, error) {
 	return ctx.EncryptWithAuthData(plaintext, nil)
 }
 
 // Implementation of encrypt method producing a JWE object.
-func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JweObject, error) {
-	obj := &JweObject{}
+func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JsonWebEncryption, error) {
+	obj := &JsonWebEncryption{}
 	obj.aad = aad
 
 	obj.protected = make(map[string]interface{})
@@ -275,7 +275,7 @@ func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JweObj
 }
 
 // Implementation of decrypt method consuming a JWE object.
-func (ctx *genericDecrypter) Decrypt(obj *JweObject) ([]byte, error) {
+func (ctx *genericDecrypter) Decrypt(obj *JsonWebEncryption) ([]byte, error) {
 	if _, critPresent := obj.getHeader("crit", nil); critPresent {
 		return nil, fmt.Errorf("square/go-jose: unsupported crit header")
 	}

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -33,7 +33,7 @@ var ecTestKey256, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 var ecTestKey384, _ = ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 var ecTestKey521, _ = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 
-func RoundtripJWE(keyAlg KeyAlgorithm, encAlg ContentEncryption, compressionAlg CompressionAlgorithm, serializer func(*JweObject) (string, error), corrupter func(*JweObject), aad []byte, encryptionKey interface{}, decryptionKey interface{}) error {
+func RoundtripJWE(keyAlg KeyAlgorithm, encAlg ContentEncryption, compressionAlg CompressionAlgorithm, serializer func(*JsonWebEncryption) (string, error), corrupter func(*JsonWebEncryption), aad []byte, encryptionKey interface{}, decryptionKey interface{}) error {
 	enc, err := NewEncrypter(keyAlg, encAlg, encryptionKey)
 	if err != nil {
 		return fmt.Errorf("error on new encrypter: %s", err)
@@ -89,12 +89,12 @@ func TestRoundtripsJWE(t *testing.T) {
 	encAlgs := []ContentEncryption{A128GCM, A192GCM, A256GCM, A128CBC_HS256, A192CBC_HS384, A256CBC_HS512}
 	zipAlgs := []CompressionAlgorithm{NONE, DEFLATE}
 
-	serializers := []func(*JweObject) (string, error){
-		func(obj *JweObject) (string, error) { return obj.CompactSerialize() },
-		func(obj *JweObject) (string, error) { return obj.FullSerialize(), nil },
+	serializers := []func(*JsonWebEncryption) (string, error){
+		func(obj *JsonWebEncryption) (string, error) { return obj.CompactSerialize() },
+		func(obj *JsonWebEncryption) (string, error) { return obj.FullSerialize(), nil },
 	}
 
-	corrupter := func(obj *JweObject) {}
+	corrupter := func(obj *JsonWebEncryption) {}
 
 	// Note: can't use AAD with compact serialization
 	aads := [][]byte{
@@ -125,21 +125,21 @@ func TestRoundtripsJWECorrupted(t *testing.T) {
 	encAlgs := []ContentEncryption{A128GCM, A192GCM, A256GCM, A128CBC_HS256, A192CBC_HS384, A256CBC_HS512}
 	zipAlgs := []CompressionAlgorithm{NONE, DEFLATE}
 
-	serializers := []func(*JweObject) (string, error){
-		func(obj *JweObject) (string, error) { return obj.CompactSerialize() },
-		func(obj *JweObject) (string, error) { return obj.FullSerialize(), nil },
+	serializers := []func(*JsonWebEncryption) (string, error){
+		func(obj *JsonWebEncryption) (string, error) { return obj.CompactSerialize() },
+		func(obj *JsonWebEncryption) (string, error) { return obj.FullSerialize(), nil },
 	}
 
-	corrupters := []func(*JweObject){
-		func(obj *JweObject) {
+	corrupters := []func(*JsonWebEncryption){
+		func(obj *JsonWebEncryption) {
 			// Set invalid AAD
 			obj.aad = []byte("###")
 		},
-		func(obj *JweObject) {
+		func(obj *JsonWebEncryption) {
 			// Set invalid ciphertext
 			obj.ciphertext = []byte("###")
 		},
-		func(obj *JweObject) {
+		func(obj *JsonWebEncryption) {
 			// Set invalid auth tag
 			obj.tag = []byte("###")
 		},
@@ -343,11 +343,11 @@ func generateTestKeys(keyAlg KeyAlgorithm, encAlg ContentEncryption) []testKey {
 }
 
 func RunRoundtripsJWE(b *testing.B, alg KeyAlgorithm, enc ContentEncryption, zip CompressionAlgorithm, priv, pub interface{}) {
-	serializer := func(obj *JweObject) (string, error) {
+	serializer := func(obj *JsonWebEncryption) (string, error) {
 		return obj.CompactSerialize()
 	}
 
-	corrupter := func(obj *JweObject) {}
+	corrupter := func(obj *JsonWebEncryption) {}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestGetHeader(t *testing.T) {
-	obj := &JweObject{
+	obj := &JsonWebEncryption{
 		protected:   map[string]interface{}{"1": "P"},
 		unprotected: map[string]interface{}{"2": "U"},
 	}
@@ -149,7 +149,7 @@ func TestFullParseJWE(t *testing.T) {
 
 type dummyDecrypter struct{}
 
-func (dec *dummyDecrypter) decryptKey(alg KeyAlgorithm, obj *JweObject, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
+func (dec *dummyDecrypter) decryptKey(alg KeyAlgorithm, obj *JsonWebEncryption, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
 	return nil, errors.New("error")
 }
 
@@ -158,7 +158,7 @@ func TestDecryptDoesNotPropagateError(t *testing.T) {
 		keyDecrypter: &dummyDecrypter{},
 	}
 
-	obj := &JweObject{
+	obj := &JsonWebEncryption{
 		protected: map[string]interface{}{"alg": string(DIRECT), "enc": string(A128GCM)},
 		recipients: []recipientInfo{
 			recipientInfo{},
@@ -176,7 +176,7 @@ func TestMissingInvalidHeaders(t *testing.T) {
 		keyDecrypter: &dummyDecrypter{},
 	}
 
-	obj := &JweObject{
+	obj := &JsonWebEncryption{
 		protected: map[string]interface{}{"enc": "A128GCM"},
 		recipients: []recipientInfo{
 			recipientInfo{},
@@ -226,7 +226,7 @@ func TestMissingInvalidHeaders(t *testing.T) {
 
 func TestCompactSerialize(t *testing.T) {
 	// Compact serialization must fail if we have unprotected headers
-	obj := &JweObject{
+	obj := &JsonWebEncryption{
 		unprotected: map[string]interface{}{"test": "test"},
 	}
 

--- a/signing.go
+++ b/signing.go
@@ -25,18 +25,18 @@ import (
 
 // Signer represents a signer which takes a payload and produces a signed JWS object.
 type Signer interface {
-	Sign(payload []byte) (*JwsObject, error)
+	Sign(payload []byte) (*JsonWebSignature, error)
 }
 
 // MultiSigner represents a signer which supports multiple recipients.
 type MultiSigner interface {
-	Sign(payload []byte) (*JwsObject, error)
+	Sign(payload []byte) (*JsonWebSignature, error)
 	AddRecipient(alg SignatureAlgorithm, signingKey interface{}) error
 }
 
 // Verifier represents a verifier which checks signatures on JWS objects.
 type Verifier interface {
-	Verify(object *JwsObject) ([]byte, error)
+	Verify(object *JsonWebSignature) ([]byte, error)
 }
 
 type payloadSigner interface {
@@ -118,8 +118,8 @@ func (ctx *genericSigner) AddRecipient(alg SignatureAlgorithm, signingKey interf
 	return nil
 }
 
-func (ctx *genericSigner) Sign(payload []byte) (*JwsObject, error) {
-	obj := &JwsObject{}
+func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
+	obj := &JsonWebSignature{}
 	obj.payload = payload
 	obj.signatures = make([]signatureInfo, len(ctx.recipients))
 
@@ -150,7 +150,7 @@ func (ctx *genericSigner) Sign(payload []byte) (*JwsObject, error) {
 	return obj, nil
 }
 
-func (ctx *genericVerifier) Verify(obj *JwsObject) ([]byte, error) {
+func (ctx *genericVerifier) Verify(obj *JsonWebSignature) ([]byte, error) {
 	for _, signature := range obj.signatures {
 		if _, critPresent := signature.getHeader("crit"); critPresent {
 			// Unsupported crit header

--- a/signing_test.go
+++ b/signing_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 )
 
-func RoundtripJWS(sigAlg SignatureAlgorithm, serializer func(*JwsObject) (string, error), corrupter func(*JwsObject), signingKey interface{}, verificationKey interface{}) error {
+func RoundtripJWS(sigAlg SignatureAlgorithm, serializer func(*JsonWebSignature) (string, error), corrupter func(*JsonWebSignature), signingKey interface{}, verificationKey interface{}) error {
 	signer, err := NewSigner(sigAlg, signingKey)
 	if err != nil {
 		return fmt.Errorf("error on new signer: %s", err)
@@ -71,12 +71,12 @@ func TestRoundtripsJWS(t *testing.T) {
 	// Test matrix
 	sigAlgs := []SignatureAlgorithm{RS256, RS384, RS512, PS256, PS384, PS512, HS256, HS384, HS512, ES256, ES384, ES512}
 
-	serializers := []func(*JwsObject) (string, error){
-		func(obj *JwsObject) (string, error) { return obj.CompactSerialize() },
-		func(obj *JwsObject) (string, error) { return obj.FullSerialize(), nil },
+	serializers := []func(*JsonWebSignature) (string, error){
+		func(obj *JsonWebSignature) (string, error) { return obj.CompactSerialize() },
+		func(obj *JsonWebSignature) (string, error) { return obj.FullSerialize(), nil },
 	}
 
-	corrupter := func(obj *JwsObject) {}
+	corrupter := func(obj *JsonWebSignature) {}
 
 	for _, alg := range sigAlgs {
 		signingKey, verificationKey := GenerateSigningTestKey(alg)
@@ -94,17 +94,17 @@ func TestRoundtripsJWSCorruptSignature(t *testing.T) {
 	// Test matrix
 	sigAlgs := []SignatureAlgorithm{RS256, RS384, RS512, PS256, PS384, PS512, HS256, HS384, HS512, ES256, ES384, ES512}
 
-	serializers := []func(*JwsObject) (string, error){
-		func(obj *JwsObject) (string, error) { return obj.CompactSerialize() },
-		func(obj *JwsObject) (string, error) { return obj.FullSerialize(), nil },
+	serializers := []func(*JsonWebSignature) (string, error){
+		func(obj *JsonWebSignature) (string, error) { return obj.CompactSerialize() },
+		func(obj *JsonWebSignature) (string, error) { return obj.FullSerialize(), nil },
 	}
 
-	corrupters := []func(*JwsObject){
-		func(obj *JwsObject) {
+	corrupters := []func(*JsonWebSignature){
+		func(obj *JsonWebSignature) {
 			// Changes bytes in signature
 			obj.signatures[0].signature[10]++
 		},
-		func(obj *JwsObject) {
+		func(obj *JsonWebSignature) {
 			// Set totally invalid signature
 			obj.signatures[0].signature = []byte("###")
 		},

--- a/symmetric.go
+++ b/symmetric.go
@@ -270,7 +270,7 @@ func (ctx *symmetricKeyCipher) encryptKey(cek []byte, alg KeyAlgorithm) (recipie
 }
 
 // Decrypt the content encryption key.
-func (ctx *symmetricKeyCipher) decryptKey(alg KeyAlgorithm, obj *JweObject, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
+func (ctx *symmetricKeyCipher) decryptKey(alg KeyAlgorithm, obj *JsonWebEncryption, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
 	switch alg {
 	case DIRECT:
 		cek := make([]byte, len(ctx.key))

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -64,7 +64,7 @@ func TestInvalidKey(t *testing.T) {
 }
 
 func TestInvalidWrappedKey(t *testing.T) {
-	obj := &JweObject{}
+	obj := &JsonWebEncryption{}
 	cipher := &symmetricKeyCipher{}
 
 	_, err := cipher.decryptKey(A128GCMKW, obj, &recipientInfo{}, nil)


### PR DESCRIPTION
Fixes #5 by removing acronyms and using full names for structs (more readable this way).
