### PR TITLE
README: removed *err* in encrypted FullSerialize() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ if err != nil {
 // Serialize the encrypted object using the full serialization format.
 // Alternatively you can also use the compact format here by calling
 // object.CompactSerialize() instead.
-serialized, err := object.FullSerialize()
+serialized := object.FullSerialize()
 
 // Parse the serialized, encrypted JWE object. An error would indicate that
 // the given input did not represent a valid message.


### PR DESCRIPTION
Just a tiny correction on the encrypted example