### PR TITLE
Make key wrap more generic

### DIFF
--- a/cipher/key_wrap.go
+++ b/cipher/key_wrap.go
@@ -17,7 +17,7 @@
 package josecipher
 
 import (
-	"crypto/aes"
+	"crypto/cipher"
 	"crypto/subtle"
 	"encoding/binary"
 	"errors"
@@ -25,15 +25,10 @@ import (
 
 var defaultIV = []byte{0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6}
 
-// AesKeyWrap wraps a content encryption key (cek) with the given key encryption key (kek).
-func AesKeyWrap(kek, cek []byte) ([]byte, error) {
+// KeyWrap implements NIST key wrapping; it wraps a content encryption key (cek) with the given block cipher.
+func KeyWrap(block cipher.Block, cek []byte) ([]byte, error) {
 	if len(cek)%8 != 0 {
 		return nil, errors.New("square/go-jose: key wrap input must be 8 byte blocks")
-	}
-
-	block, err := aes.NewCipher(kek)
-	if err != nil {
-		return nil, err
 	}
 
 	n := len(cek) / 8
@@ -70,15 +65,10 @@ func AesKeyWrap(kek, cek []byte) ([]byte, error) {
 	return out, nil
 }
 
-// AesKeyUnwrap unwraps a wrapped key (ciphertext) with the given key encryption key (kek).
-func AesKeyUnwrap(kek, ciphertext []byte) ([]byte, error) {
+// KeyUnwrap implements NIST key unwrapping; it unwraps a content encryption key (cek) with the given block cipher.
+func KeyUnwrap(block cipher.Block, ciphertext []byte) ([]byte, error) {
 	if len(ciphertext)%8 != 0 {
 		return nil, errors.New("square/go-jose: key wrap input must be 8 byte blocks")
-	}
-
-	block, err := aes.NewCipher(kek)
-	if err != nil {
-		return nil, err
 	}
 
 	n := (len(ciphertext) / 8) - 1

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -117,7 +117,7 @@ func main() {
 				exitOnError(err, "unable to parse message")
 
 				plaintext, err := obj.Decrypt(priv)
-				exitOnError(err, "unable to encrypt message")
+				exitOnError(err, "unable to decrypt message")
 
 				writeOutput(c.String("output"), plaintext)
 			},

--- a/symmetric.go
+++ b/symmetric.go
@@ -236,7 +236,12 @@ func (ctx *symmetricKeyCipher) encryptKey(cek []byte, alg KeyAlgorithm) (recipie
 			encryptedKey: parts.ciphertext,
 		}, nil
 	case A128KW, A192KW, A256KW:
-		jek, err := josecipher.AesKeyWrap(ctx.key, cek)
+		block, err := aes.NewCipher(ctx.key)
+		if err != nil {
+			return recipientInfo{}, err
+		}
+
+		jek, err := josecipher.KeyWrap(block, cek)
 		if err != nil {
 			return recipientInfo{}, err
 		}
@@ -273,7 +278,12 @@ func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipien
 
 		return cek, nil
 	case A128KW, A192KW, A256KW:
-		cek, err := josecipher.AesKeyUnwrap(ctx.key, recipient.encryptedKey)
+		block, err := aes.NewCipher(ctx.key)
+		if err != nil {
+			return nil, err
+		}
+
+		cek, err := josecipher.KeyUnwrap(block, recipient.encryptedKey)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This makes the key wrap implementation the `josecipher` subpackage more generic, so that it can be used with block ciphers other than AES.