### PR TITLE
first pass at JWT private keys and KeyId for signing

### DIFF
--- a/jwk_test.go
+++ b/jwk_test.go
@@ -17,7 +17,12 @@
 package jose
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -52,5 +57,91 @@ func TestParseInvalidECKeys(t *testing.T) {
 		if err == nil {
 			t.Error("ec parser incorrectly parsed invalid key", jwk)
 		}
+	}
+}
+
+func TestRoundtripRsaPrivate(t *testing.T) {
+	rsa, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Error("problem generating test RSA key", err)
+	}
+
+	var jwk rawJsonWebKey
+	jwk.fromRsaPrivateKey(rsa)
+
+	rsa2, err := jwk.rsaPrivateKey()
+	if err != nil {
+		t.Error("problem converting RSA private -> JWK", err)
+	}
+
+	if rsa2.N.Cmp(rsa.N) != 0 {
+		t.Error("RSA private N mismatch")
+	}
+	if rsa2.E != rsa.E {
+		t.Error("RSA private E mismatch")
+	}
+	if rsa2.D.Cmp(rsa.D) != 0 {
+		t.Error("RSA private D mismatch")
+	}
+	if len(rsa2.Primes) != 2 {
+		t.Error("RSA private roundtrip expected two primes")
+	}
+	if rsa2.Primes[0].Cmp(rsa.Primes[0]) != 0 {
+		t.Error("RSA private P mismatch")
+	}
+	if rsa2.Primes[1].Cmp(rsa.Primes[1]) != 0 {
+		t.Error("RSA private Q mismatch")
+	}
+}
+
+func TestRoundtripEcPrivate(t *testing.T) {
+	ec, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Error("problem generating test ECDSA key", err)
+	}
+
+	var jwk rawJsonWebKey
+	jwk.fromEcPrivateKey(ec)
+
+	ec2, err := jwk.ecPrivateKey()
+	if err != nil {
+		t.Error("problem converting ECDSA private -> JWK", err)
+	}
+
+	if !reflect.DeepEqual(ec2.Curve, ec.Curve) {
+		t.Error("ECDSA private curve mismatch")
+	}
+	if ec2.X.Cmp(ec.X) != 0 {
+		t.Error("ECDSA X mismatch")
+	}
+	if ec2.Y.Cmp(ec.Y) != 0 {
+		t.Error("ECDSA Y mismatch")
+	}
+	if ec2.D.Cmp(ec.D) != 0 {
+		t.Error("ECDSA D mismatch")
+	}
+}
+
+func TestKidMarshaling(t *testing.T) {
+	kid := "DEADBEEF"
+
+	ec, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Error("problem generating test ECDSA key", err)
+	}
+
+	jwk := JsonWebKey{key: ec, kid: kid}
+	jsonbar, err := jwk.MarshalJSON()
+	if err != nil {
+		t.Error("problem marshaling", err)
+	}
+	var jwk2 JsonWebKey
+	err = jwk2.UnmarshalJSON(jsonbar)
+	if err != nil {
+		t.Error("problem unmarshalling", err)
+	}
+
+	if jwk2.kid != kid {
+		t.Error("kid did not roundtrip JSON marshalling")
 	}
 }

--- a/shared.go
+++ b/shared.go
@@ -45,7 +45,8 @@ var (
 
 	// ErrUnsupportedKeyType indicates that the given key type/format is not
 	// supported. This occurs when trying to instantiate an encrypter and passing
-	// it a key of an unrecognized type.
+	// it a key of an unrecognized type or with unsupported parameters, such as
+	// an RSA private key with more than two primes.
 	ErrUnsupportedKeyType = errors.New("square/go-jose: unsupported key type/format")
 
 	// ErrNotSupported serialization of object is not supported. This occurs when


### PR DESCRIPTION
Here is an attempt at adding RSA and ECDSA private key support to the JWK code, along with trying to get KeyId specified in the `kid` field of a JWS signing key passed through the signature headers so that it is available to recipients between the parsing and verification stage. Intended to address #17. I hope this may be of some use to folks, and apologies for any ugliness therein.