### PR TITLE
Expose the "alg" field on a JWK

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -32,6 +32,7 @@ type rawJsonWebKey struct {
 	Kty string      `json:"kty,omitempty"`
 	Kid string      `json:"kid,omitempty"`
 	Crv string      `json:"crv,omitempty"`
+	Alg string      `json:"alg,omitempty"`
 	X   *byteBuffer `json:"x,omitempty"`
 	Y   *byteBuffer `json:"y,omitempty"`
 	N   *byteBuffer `json:"n,omitempty"`
@@ -50,8 +51,9 @@ type rawJsonWebKey struct {
 
 // JsonWebKey represents a public or private key in JWK format.
 type JsonWebKey struct {
-	Key   interface{}
-	KeyID string
+	Key       interface{}
+	KeyID     string
+	Algorithm string
 }
 
 // MarshalJSON serializes the given key to its JSON representation.
@@ -77,6 +79,7 @@ func (k *JsonWebKey) MarshalJSON() ([]byte, error) {
 	}
 
 	raw.Kid = k.KeyID
+	raw.Alg = k.Algorithm
 
 	return json.Marshal(raw)
 }
@@ -108,7 +111,7 @@ func (k *JsonWebKey) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	if err == nil {
-		*k = JsonWebKey{Key: key, KeyID: raw.Kid}
+		*k = JsonWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg}
 	}
 	return
 }

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -121,7 +121,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	kid := "DEADBEEF"
 
 	for i, key := range []interface{}{ecTestKey256, ecTestKey384, ecTestKey521, rsaTestKey} {
-		jwk := JsonWebKey{Key: key, KeyID: kid}
+		jwk := JsonWebKey{Key: key, KeyID: kid, Algorithm: "foo"}
 		jsonbar, err := jwk.MarshalJSON()
 		if err != nil {
 			t.Error("problem marshaling", i, err)
@@ -144,6 +144,10 @@ func TestMarshalUnmarshal(t *testing.T) {
 
 		if jwk2.KeyID != kid {
 			t.Error("kid did not roundtrip JSON marshalling", i)
+		}
+
+		if jwk2.Algorithm != "foo" {
+			t.Error("alg did not roundtrip JSON marshalling", i)
 		}
 	}
 }


### PR DESCRIPTION
In order to properly validate a JSON Web Token using a JSON Web Key one should compare the "alg" header on the JWT to the "alg" field on the JWK. This change exposes the "alg" field on the JWK to make that possible.