### PR TITLE
Fix sign/verify when protected header is absent.

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -48,6 +48,12 @@ func mustSerializeJSON(value interface{}) []byte {
 	if err != nil {
 		panic(err)
 	}
+	// Note: It's not possible to directly check whether the data pointed at by an
+	// interface is a nil pointer, so we do this hacky workaround.
+	// https://groups.google.com/forum/#!topic/golang-nuts/wnH302gBa4I
+	if string(out) == "null" {
+		panic("Tried to serialize a nil pointer.")
+	}
 	return out
 }
 

--- a/encoding.go
+++ b/encoding.go
@@ -42,12 +42,21 @@ func base64URLDecode(data string) ([]byte, error) {
 	return base64.URLEncoding.DecodeString(data)
 }
 
-// Helper function to serialize known-good objects
+// Helper function to serialize known-good objects.
+// Precondition: value is not a nil pointer.
 func mustSerializeJSON(value interface{}) []byte {
 	out, err := json.Marshal(value)
 	if err != nil {
 		panic(err)
 	}
+	// We never want to serialize the top-level value "null," since it's not a
+	// valid JOSE message. But if a caller passes in a nil pointer to this method,
+	// json.Marshal will happily serialize it as the top-level value "null". If
+	// that value is then embedded in another operation, for instance by being
+	// base64-encoded and fed as input to a signing algorithm
+	// (https://github.com/square/go-jose/issues/22), the result will be
+	// incorrect. Because this method is intended for known-good objects, and a nil
+	// pointer is not a known-good object, we are free to panic in this case.
 	// Note: It's not possible to directly check whether the data pointed at by an
 	// interface is a nil pointer, so we do this hacky workaround.
 	// https://groups.google.com/forum/#!topic/golang-nuts/wnH302gBa4I

--- a/jws.go
+++ b/jws.go
@@ -75,10 +75,12 @@ func (sig Signature) mergedHeaders() rawHeader {
 func (obj JsonWebSignature) computeAuthData(signature *Signature) []byte {
 	var serializedProtected string
 
-	if signature.original == nil {
+	if signature.original != nil && signature.original.Protected != nil {
+		serializedProtected = signature.original.Protected.base64()
+	} else if signature.protected != nil {
 		serializedProtected = base64URLEncode(mustSerializeJSON(signature.protected))
 	} else {
-		serializedProtected = signature.original.Protected.base64()
+		serializedProtected = ""
 	}
 
 	return []byte(fmt.Sprintf("%s.%s",

--- a/jws_test.go
+++ b/jws_test.go
@@ -18,6 +18,7 @@ package jose
 
 import (
 	"testing"
+	"fmt"
 )
 
 func TestCompactParseJWS(t *testing.T) {
@@ -86,6 +87,40 @@ func TestFullParseJWS(t *testing.T) {
 		if err == nil {
 			t.Error("Able to parse invalid message", err, failures[i])
 		}
+	}
+}
+
+func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
+	input := `{
+			"header": {
+					"alg": "RS256",
+					"jwk": {
+							"e": "AQAB",
+							"kty": "RSA",
+							"n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_pSUHWXNmS9R4NZ3t2fQAzPeW7jOfF0LKuJRGkekx6tXP1uSnNibgpJULNc4208dgBaCHo3mvaE2HV2GmVl1yxwWX5QZZkGQGjNDZYnjFfa2DKVvFs0QbAk21ROm594kAxlRlMMrvqlf24Eq4ERO0ptzpZgm_3j_e4hGRD39gJS7kAzK-j2cacFQ5Qi2Y6wZI2p-FCq_wiYsfEAIkATPBiLKl_6d_Jfcvs_impcXQ"
+					}
+			},
+			"payload": "Zm9vCg",
+			"signature": "hRt2eYqBd_MyMRNIh8PEIACoFtmBi7BHTLBaAhpSU6zyDAFdEBaX7us4VB9Vo1afOL03Q8iuoRA0AT4akdV_mQTAQ_jhTcVOAeXPr0tB8b8Q11UPQ0tXJYmU4spAW2SapJIvO50ntUaqU05kZd0qw8-noH1Lja-aNnU-tQII4iYVvlTiRJ5g8_CADsvJqOk6FcHuo2mG643TRnhkAxUtazvHyIHeXMxydMMSrpwUwzMtln4ZJYBNx4QGEq6OhpAD_VSp-w8Lq5HOwGQoNs0bPxH1SGrArt67LFQBfjlVr94E1sn26p4vigXm83nJdNhWAMHHE9iV67xN-r29LT-FjA"
+	}`
+
+	jws, err := ParseSigned(input)
+	if err != nil {
+		t.Error("Unable to parse valid message.")
+	}
+	if len(jws.Signatures) != 1 {
+		t.Error("Too many or too few signatures.")
+	}
+	sig := jws.Signatures[0]
+	if sig.Header.JsonWebKey == nil {
+		t.Error("No JWK in signature header.")
+	}
+	payload, err := jws.Verify(sig.Header.JsonWebKey)
+	if err != nil {
+		t.Error(fmt.Sprintf("Signature did not validate: %v", err))
+	}
+	if string(payload) != "foo\n" {
+		t.Error("Payload was incorrect: '%v' should have been 'foo\\n'", payload)
 	}
 }
 


### PR DESCRIPTION
Previously, if there was no protected header, we would attempt to serialize a
nil pointer. json.Marshal would happily serialize it as the literal string
"null", which would cause an incorrect signature or a verify error.

Instead, if there is no protected header, explicitly set the protected part of
the input to be signed to the empty string.

Fixes https://github.com/square/go-jose/issues/22