### PR TITLE
Check key size on ECDSA signing

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -440,6 +440,9 @@ func (ctx ecDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm)
 		keyBytes += 1
 	}
 
+	// We serialize the outpus (r and s) into big-endian byte arrays and pad
+	// them with zeros on the left to make sure the sizes work out. Both arrays
+	// must be keyBytes long, and the output must be 2*keyBytes long.
 	rBytes := r.Bytes()
 	rBytesPadded := make([]byte, keyBytes)
 	copy(rBytesPadded[keyBytes-len(rBytes):], rBytes)

--- a/asymmetric_test.go
+++ b/asymmetric_test.go
@@ -398,3 +398,34 @@ func BenchmarkPKCSDecryptWithInvalidPayloads(b *testing.B) {
 		}
 	}
 }
+
+func TestInvalidEllipticCurve(t *testing.T) {
+	signer256 := ecDecrypterSigner{privateKey: ecTestKey256}
+	signer384 := ecDecrypterSigner{privateKey: ecTestKey384}
+	signer521 := ecDecrypterSigner{privateKey: ecTestKey521}
+
+	_, err := signer256.signPayload([]byte{}, ES384)
+	if err == nil {
+		t.Error("should not generate ES384 signature with P-256 key")
+	}
+	_, err = signer256.signPayload([]byte{}, ES512)
+	if err == nil {
+		t.Error("should not generate ES512 signature with P-256 key")
+	}
+	_, err = signer384.signPayload([]byte{}, ES256)
+	if err == nil {
+		t.Error("should not generate ES256 signature with P-384 key")
+	}
+	_, err = signer384.signPayload([]byte{}, ES512)
+	if err == nil {
+		t.Error("should not generate ES512 signature with P-384 key")
+	}
+	_, err = signer521.signPayload([]byte{}, ES256)
+	if err == nil {
+		t.Error("should not generate ES256 signature with P-521 key")
+	}
+	_, err = signer521.signPayload([]byte{}, ES384)
+	if err == nil {
+		t.Error("should not generate ES384 signature with P-521 key")
+	}
+}


### PR DESCRIPTION
Check key size on ECDSA signing, fixes a panic when using a key with incorrect algorithm (e.g. using ES256 signature with P-384 key).

R: @dgalling 