### PR TITLE
Marshal JWK with non-pointer receiver.

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -57,7 +57,7 @@ type JsonWebKey struct {
 }
 
 // MarshalJSON serializes the given key to its JSON representation.
-func (k *JsonWebKey) MarshalJSON() ([]byte, error) {
+func (k JsonWebKey) MarshalJSON() ([]byte, error) {
 	var raw *rawJsonWebKey
 	var err error
 


### PR DESCRIPTION
When marshaling structs that contain an embedded JWK, if that key member is not
a pointer, json.Marshal(struct) will silently fail to call the custom JWK
marshaling code, for reasons detailed here:

https://stackoverflow.com/questions/21390979/custom-marshaljson-never-gets-called-in-go

Instead it will naively marshal the JWK as a struct, leading to output like:

{
  "N": 1233589723897239847293874928374928734823947298347,
  "E": 65537
}

By changing the receiver to a non-pointer, we can marshal both pointer and
non-pointer fields.