### PR TITLE
Add support for JWK thumbprints

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -131,6 +131,22 @@ func newBuffer(data []byte) *byteBuffer {
 	}
 }
 
+func newZeroPaddedBuffer(data []byte, length int) *byteBuffer {
+	if len(data) >= length {
+		return newBuffer(data)
+	}
+
+	padLength := length - len(data)
+	paddedData := make([]byte, length)
+	for i := range paddedData {
+		paddedData[i] = 0
+		if i >= padLength {
+			paddedData[i] = data[i-padLength]
+		}
+	}
+	return newBuffer(paddedData)
+}
+
 func (b *byteBuffer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(b.base64())
 }

--- a/jwk.go
+++ b/jwk.go
@@ -17,6 +17,7 @@
 package jose
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
@@ -114,6 +115,64 @@ func (k *JsonWebKey) UnmarshalJSON(data []byte) (err error) {
 		*k = JsonWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg}
 	}
 	return
+}
+
+const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`
+const ecThumbprintTemplate = `{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`
+
+func ecThumbprintInput(key *ecdsa.PublicKey) (string, error) {
+	crv := ""
+	coordLength := 0
+	switch key.Curve {
+	case elliptic.P256():
+		crv = "P-256"
+		coordLength = 32
+	case elliptic.P384():
+		crv = "P-384"
+		coordLength = 48
+	case elliptic.P521():
+		crv = "P-521"
+		coordLength = 66
+	default:
+		return "", fmt.Errorf("square/go-jose: unsupported/unknown elliptic curve")
+	}
+
+	return fmt.Sprintf(ecThumbprintTemplate, crv,
+		newZeroPaddedBuffer(key.X.Bytes(), coordLength).base64(),
+		newZeroPaddedBuffer(key.Y.Bytes(), coordLength).base64()), nil
+}
+
+func rsaThumbprintInput(key *rsa.PublicKey) (string, error) {
+	return fmt.Sprintf(rsaThumbprintTemplate,
+		newBuffer(big.NewInt(int64(key.E)).Bytes()).base64(),
+		newBuffer(key.N.Bytes()).base64()), nil
+}
+
+// Thumbprint computes the JWK Thumbprint of a key using the
+// indicated hash algorithm.
+func (k *JsonWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
+	var input string
+	var err error
+	switch key := k.Key.(type) {
+	case *ecdsa.PublicKey:
+		input, err = ecThumbprintInput(key)
+	case *rsa.PublicKey:
+		input, err = rsaThumbprintInput(key)
+	case *ecdsa.PrivateKey:
+		input, err = ecThumbprintInput(key.Public().(*ecdsa.PublicKey))
+	case *rsa.PrivateKey:
+		input, err = rsaThumbprintInput(key.Public().(*rsa.PublicKey))
+	default:
+		return nil, fmt.Errorf("square/go-jose: unkown key type '%s'", reflect.TypeOf(key))
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	h := hash.New()
+	h.Write([]byte(input))
+	return h.Sum(nil), nil
 }
 
 func (key rawJsonWebKey) rsaPublicKey() (*rsa.PublicKey, error) {

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math/big"


### PR DESCRIPTION
The IETF draft defining [JWK thumbprints](http://tools.ietf.org/html/draft-ietf-jose-jwk-thumbprint) is almost an RFC.  It would be helpful for this library to support thumbprints in the standard format.