### PR TITLE
Expose signature value in JWS signatures

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -252,7 +252,7 @@ func (ctx rsaDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm
 	}
 
 	return Signature{
-		signature: out,
+		Signature: out,
 		protected: &rawHeader{},
 	}, nil
 }
@@ -454,7 +454,7 @@ func (ctx ecDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm)
 	out := append(rBytesPadded, sBytesPadded...)
 
 	return Signature{
-		signature: out,
+		Signature: out,
 		protected: &rawHeader{},
 	}, nil
 }

--- a/jws.go
+++ b/jws.go
@@ -46,8 +46,12 @@ type JsonWebSignature struct {
 
 // Signature represents a single signature over the JWS payload and protected header.
 type Signature struct {
-	Header    JoseHeader
+	// Header fields, such as the signature algorithm
+	Header JoseHeader
+
+	// The actual signature value
 	Signature []byte
+
 	protected *rawHeader
 	header    *rawHeader
 	original  *rawSignatureInfo

--- a/jws.go
+++ b/jws.go
@@ -47,9 +47,9 @@ type JsonWebSignature struct {
 // Signature represents a single signature over the JWS payload and protected header.
 type Signature struct {
 	Header    JoseHeader
+	Signature []byte
 	protected *rawHeader
 	header    *rawHeader
-	signature []byte
 	original  *rawSignatureInfo
 }
 
@@ -122,7 +122,7 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 		}
 
 		signature.header = parsed.Header
-		signature.signature = parsed.Signature.bytes()
+		signature.Signature = parsed.Signature.bytes()
 		// Make a fake "original" rawSignatureInfo to store the unprocessed
 		// Protected header. This is necessary because the Protected header can
 		// contain arbitrary fields not registered as part of the spec. See
@@ -134,7 +134,7 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 		// header struct only if those bytes are not available.
 		signature.original = &rawSignatureInfo{
 			Protected: parsed.Protected,
-			Header: parsed.Header,
+			Header:    parsed.Header,
 			Signature: parsed.Signature,
 		}
 
@@ -151,7 +151,7 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 			}
 		}
 
-		obj.Signatures[i].signature = sig.Signature.bytes()
+		obj.Signatures[i].Signature = sig.Signature.bytes()
 
 		// Copy value of sig
 		original := sig
@@ -206,7 +206,7 @@ func (obj JsonWebSignature) CompactSerialize() (string, error) {
 		"%s.%s.%s",
 		base64URLEncode(serializedProtected),
 		base64URLEncode(obj.payload),
-		base64URLEncode(obj.Signatures[0].signature)), nil
+		base64URLEncode(obj.Signatures[0].Signature)), nil
 }
 
 // FullSerialize serializes an object using the full JSON serialization format.
@@ -219,7 +219,7 @@ func (obj JsonWebSignature) FullSerialize() string {
 		serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
 		raw.Protected = newBuffer(serializedProtected)
 		raw.Header = obj.Signatures[0].header
-		raw.Signature = newBuffer(obj.Signatures[0].signature)
+		raw.Signature = newBuffer(obj.Signatures[0].Signature)
 	} else {
 		raw.Signatures = make([]rawSignatureInfo, len(obj.Signatures))
 		for i, signature := range obj.Signatures {
@@ -228,7 +228,7 @@ func (obj JsonWebSignature) FullSerialize() string {
 			raw.Signatures[i] = rawSignatureInfo{
 				Protected: newBuffer(serializedProtected),
 				Header:    signature.header,
-				Signature: newBuffer(signature.signature),
+				Signature: newBuffer(signature.Signature),
 			}
 		}
 	}

--- a/jws_test.go
+++ b/jws_test.go
@@ -17,8 +17,8 @@
 package jose
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 )
 
 func TestCompactParseJWS(t *testing.T) {

--- a/signing.go
+++ b/signing.go
@@ -172,7 +172,7 @@ func (obj JsonWebSignature) Verify(verificationKey interface{}) ([]byte, error) 
 
 		input := obj.computeAuthData(&signature)
 		alg := SignatureAlgorithm(headers.Alg)
-		err := verifier.verifyPayload(input, signature.signature, alg)
+		err := verifier.verifyPayload(input, signature.Signature, alg)
 		if err == nil {
 			return obj.payload, nil
 		}

--- a/signing_test.go
+++ b/signing_test.go
@@ -109,11 +109,11 @@ func TestRoundtripsJWSCorruptSignature(t *testing.T) {
 	corrupters := []func(*JsonWebSignature){
 		func(obj *JsonWebSignature) {
 			// Changes bytes in signature
-			obj.Signatures[0].signature[10]++
+			obj.Signatures[0].Signature[10]++
 		},
 		func(obj *JsonWebSignature) {
 			// Set totally invalid signature
-			obj.Signatures[0].signature = []byte("###")
+			obj.Signatures[0].Signature = []byte("###")
 		},
 	}
 

--- a/symmetric.go
+++ b/symmetric.go
@@ -301,7 +301,7 @@ func (ctx symmetricMac) signPayload(payload []byte, alg SignatureAlgorithm) (Sig
 	}
 
 	return Signature{
-		signature: mac,
+		Signature: mac,
 		protected: &rawHeader{},
 	}, nil
 }


### PR DESCRIPTION
Boulder needs to do calculations on the signature value in a JWS.  This PR just changes `signature` to `Signature` so that it's visible.