### PR TITLE
Use fixed size buffers for EC coordinates

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -132,6 +132,14 @@ func newBuffer(data []byte) *byteBuffer {
 	}
 }
 
+func newFixedSizeBuffer(data []byte, length int) *byteBuffer {
+	if len(data) > length {
+		panic("square/go-jose: invalid call to newFixedSizeBuffer (len(data) > length)")
+	}
+	pad := make([]byte, length-len(data))
+	return newBuffer(append(pad, data...))
+}
+
 func newBufferFromInt(num uint64) *byteBuffer {
 	data := make([]byte, 8)
 	binary.BigEndian.PutUint64(data, num)

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -118,3 +118,33 @@ func TestByteBufferTrim(t *testing.T) {
 		t.Error("Byte buffer for integer '65537' should contain [0x01, 0x00, 0x01]")
 	}
 }
+
+func TestFixedSizeBuffer(t *testing.T) {
+	data0 := []byte{}
+	data1 := []byte{1}
+	data2 := []byte{1, 2}
+	data3 := []byte{1, 2, 3}
+	data4 := []byte{1, 2, 3, 4}
+
+	buf0 := newFixedSizeBuffer(data0, 4)
+	buf1 := newFixedSizeBuffer(data1, 4)
+	buf2 := newFixedSizeBuffer(data2, 4)
+	buf3 := newFixedSizeBuffer(data3, 4)
+	buf4 := newFixedSizeBuffer(data4, 4)
+
+	if !bytes.Equal(buf0.data, []byte{0, 0, 0, 0}) {
+		t.Error("Invalid padded buffer for buf0")
+	}
+	if !bytes.Equal(buf1.data, []byte{0, 0, 0, 1}) {
+		t.Error("Invalid padded buffer for buf1")
+	}
+	if !bytes.Equal(buf2.data, []byte{0, 0, 1, 2}) {
+		t.Error("Invalid padded buffer for buf2")
+	}
+	if !bytes.Equal(buf3.data, []byte{0, 1, 2, 3}) {
+		t.Error("Invalid padded buffer for buf3")
+	}
+	if !bytes.Equal(buf4.data, []byte{1, 2, 3, 4}) {
+		t.Error("Invalid padded buffer for buf4")
+	}
+}

--- a/jwk.go
+++ b/jwk.go
@@ -160,24 +160,28 @@ func (key rawJsonWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 
 func fromEcPublicKey(pub *ecdsa.PublicKey) (*rawJsonWebKey, error) {
 	if pub == nil || pub.X == nil || pub.Y == nil {
-		return nil, fmt.Errorf("square/go-jose: invalid EC key")
+		return nil, fmt.Errorf("square/go-jose: invalid EC key (nil, or X/Y missing)")
+	}
+
+	name, err := curveName(pub.Curve)
+	if err != nil {
+		return nil, err
+	}
+
+	size := curveSize(pub.Curve)
+
+	xBytes := pub.X.Bytes()
+	yBytes := pub.Y.Bytes()
+
+	if len(xBytes) > size || len(yBytes) > size {
+		return nil, fmt.Errorf("square/go-jose: invalid EC key (X/Y too large)")
 	}
 
 	key := &rawJsonWebKey{
 		Kty: "EC",
-		X:   newBuffer(pub.X.Bytes()),
-		Y:   newBuffer(pub.Y.Bytes()),
-	}
-
-	switch pub.Curve {
-	case elliptic.P256():
-		key.Crv = "P-256"
-	case elliptic.P384():
-		key.Crv = "P-384"
-	case elliptic.P521():
-		key.Crv = "P-521"
-	default:
-		return nil, fmt.Errorf("square/go-jose: unsupported/unknown elliptic curve")
+		Crv: name,
+		X:   newFixedSizeBuffer(xBytes, size),
+		Y:   newFixedSizeBuffer(yBytes, size),
 	}
 
 	return key, nil

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -28,6 +28,21 @@ import (
 	"testing"
 )
 
+func TestCurveSize(t *testing.T) {
+	size256 := curveSize(elliptic.P256())
+	size384 := curveSize(elliptic.P384())
+	size521 := curveSize(elliptic.P521())
+	if size256 != 32 {
+		t.Error("P-256 have 32 bytes")
+	}
+	if size384 != 48 {
+		t.Error("P-384 have 48 bytes")
+	}
+	if size521 != 66 {
+		t.Error("P-521 have 66 bytes")
+	}
+}
+
 func TestRoundtripRsaPrivate(t *testing.T) {
 	jwk, err := fromRsaPrivateKey(rsaTestKey)
 	if err != nil {

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -110,6 +110,27 @@ func TestRsaPrivateExcessPrimes(t *testing.T) {
 	}
 }
 
+func TestRoundtripEcPublic(t *testing.T) {
+	for i, ecTestKey := range []*ecdsa.PrivateKey{ecTestKey256, ecTestKey384, ecTestKey521} {
+		jwk, err := fromEcPublicKey(&ecTestKey.PublicKey)
+
+		ec2, err := jwk.ecPublicKey()
+		if err != nil {
+			t.Error("problem converting ECDSA private -> JWK", i, err)
+		}
+
+		if !reflect.DeepEqual(ec2.Curve, ecTestKey.Curve) {
+			t.Error("ECDSA private curve mismatch", i)
+		}
+		if ec2.X.Cmp(ecTestKey.X) != 0 {
+			t.Error("ECDSA X mismatch", i)
+		}
+		if ec2.Y.Cmp(ecTestKey.Y) != 0 {
+			t.Error("ECDSA Y mismatch", i)
+		}
+	}
+}
+
 func TestRoundtripEcPrivate(t *testing.T) {
 	for i, ecTestKey := range []*ecdsa.PrivateKey{ecTestKey256, ecTestKey384, ecTestKey521} {
 		jwk, err := fromEcPrivateKey(ecTestKey)

--- a/shared.go
+++ b/shared.go
@@ -17,7 +17,9 @@
 package jose
 
 import (
+	"crypto/elliptic"
 	"errors"
+	"fmt"
 )
 
 // KeyAlgorithm represents a key management algorithm.
@@ -181,4 +183,32 @@ func (dst *rawHeader) merge(src *rawHeader) {
 	if dst.Jwk == nil {
 		dst.Jwk = src.Jwk
 	}
+}
+
+// Get JOSE name of curve
+func curveName(crv elliptic.Curve) (string, error) {
+	switch crv {
+	case elliptic.P256():
+		return "P-256", nil
+	case elliptic.P384():
+		return "P-384", nil
+	case elliptic.P521():
+		return "P-521", nil
+	default:
+		return "", fmt.Errorf("square/go-jose: unsupported/unknown elliptic curve")
+	}
+}
+
+// Get size of curve
+func curveSize(crv elliptic.Curve) int {
+	bits := crv.Params().BitSize
+
+	div := bits / 8
+	mod := bits % 8
+
+	if mod == 0 {
+		return div
+	}
+
+	return div + 1
 }

--- a/shared.go
+++ b/shared.go
@@ -199,7 +199,7 @@ func curveName(crv elliptic.Curve) (string, error) {
 	}
 }
 
-// Get size of curve
+// Get size of curve in bytes
 func curveSize(crv elliptic.Curve) int {
 	bits := crv.Params().BitSize
 


### PR DESCRIPTION
Coordinates must have a fixed size.

Changes:
  * Add new constructor for fixed-size byte buffers
  * Add helper functions for curve name/size
  * Update JWK serialization code

R: @dgalling @sqshh 