### PR TITLE
Add support for the nonce header parameter

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -219,7 +219,7 @@ func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JsonWe
 		return nil, err
 	}
 
-	obj.protected.merge(&headers)
+	obj.protected.merge(&headers, true)
 
 	for i, info := range ctx.recipients {
 		recipient, err := info.keyEncrypter.encryptKey(cek, info.keyAlg)
@@ -234,7 +234,7 @@ func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JsonWe
 	if len(ctx.recipients) == 1 {
 		// Move per-recipient headers into main protected header if there's
 		// only a single recipient.
-		obj.protected.merge(obj.recipients[0].header)
+		obj.protected.merge(obj.recipients[0].header, true)
 		obj.recipients[0].header = nil
 	}
 

--- a/crypter.go
+++ b/crypter.go
@@ -219,7 +219,7 @@ func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JsonWe
 		return nil, err
 	}
 
-	obj.protected.merge(&headers, true)
+	obj.protected.merge(&headers)
 
 	for i, info := range ctx.recipients {
 		recipient, err := info.keyEncrypter.encryptKey(cek, info.keyAlg)
@@ -234,7 +234,7 @@ func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JsonWe
 	if len(ctx.recipients) == 1 {
 		// Move per-recipient headers into main protected header if there's
 		// only a single recipient.
-		obj.protected.merge(obj.recipients[0].header, true)
+		obj.protected.merge(obj.recipients[0].header)
 		obj.recipients[0].header = nil
 	}
 

--- a/jwe.go
+++ b/jwe.go
@@ -70,11 +70,11 @@ func (obj JsonWebEncryption) GetAuthData() []byte {
 // Get the merged header values
 func (obj JsonWebEncryption) mergedHeaders(recipient *recipientInfo) rawHeader {
 	out := rawHeader{}
-	out.merge(obj.protected)
-	out.merge(obj.unprotected)
+	out.merge(obj.protected, true)
+	out.merge(obj.unprotected, false)
 
 	if recipient != nil {
-		out.merge(recipient.header)
+		out.merge(recipient.header, false)
 	}
 
 	return out

--- a/jwe.go
+++ b/jwe.go
@@ -132,7 +132,7 @@ func (parsed *rawJsonWebEncryption) sanitized() (*JsonWebEncryption, error) {
 	// Check that there is not a nonce in the unprotected headers
 	if (parsed.Unprotected != nil && parsed.Unprotected.Nonce != "") ||
 		(parsed.Header != nil && parsed.Header.Nonce != "") {
-		return nil, fmt.Errorf("square/go-jose: Nonce parameter included in unprotected header")
+		return nil, ErrUnprotectedNonce
 	}
 
 	if parsed.Protected != nil && len(parsed.Protected.bytes()) > 0 {
@@ -159,7 +159,7 @@ func (parsed *rawJsonWebEncryption) sanitized() (*JsonWebEncryption, error) {
 
 			// Check that there is not a nonce in the unprotected header
 			if parsed.Recipients[r].Header != nil && parsed.Recipients[r].Header.Nonce != "" {
-				return nil, fmt.Errorf("square/go-jose: Nonce parameter included in unprotected header")
+				return nil, ErrUnprotectedNonce
 			}
 
 			obj.recipients[r].header = parsed.Recipients[r].Header

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -154,16 +154,16 @@ func TestRejectUnprotectedJWENonce(t *testing.T) {
 
 	// Flattened JSON
 	input := `{
-      "header":  {
-        "alg": "XYZ", "enc": "XYZ",
-        "nonce": "should-cause-an-error"
-      },
-      "encrypted_key": "does-not-matter",
-      "aad": "does-not-matter",
-      "iv": "does-not-matter",
-      "ciphertext": "does-not-matter",
-      "tag": "does-not-matter"
-  }`
+	"header":  {
+		"alg": "XYZ", "enc": "XYZ",
+		"nonce": "should-cause-an-error"
+	},
+	"encrypted_key": "does-not-matter",
+	"aad": "does-not-matter",
+	"iv": "does-not-matter",
+	"ciphertext": "does-not-matter",
+	"tag": "does-not-matter"
+	}`
 	_, err := ParseEncrypted(input)
 	if err == nil {
 		t.Error("JWE with an unprotected nonce parsed as valid.")
@@ -172,16 +172,16 @@ func TestRejectUnprotectedJWENonce(t *testing.T) {
 	}
 
 	input = `{
-      "unprotected":  {
-        "alg": "XYZ", "enc": "XYZ",
-        "nonce": "should-cause-an-error"
-      },
-      "encrypted_key": "does-not-matter",
-      "aad": "does-not-matter",
-      "iv": "does-not-matter",
-      "ciphertext": "does-not-matter",
-      "tag": "does-not-matter"
-  }`
+		"unprotected":  {
+			"alg": "XYZ", "enc": "XYZ",
+			"nonce": "should-cause-an-error"
+		},
+		"encrypted_key": "does-not-matter",
+		"aad": "does-not-matter",
+		"iv": "does-not-matter",
+		"ciphertext": "does-not-matter",
+		"tag": "does-not-matter"
+	}`
 	_, err = ParseEncrypted(input)
 	if err == nil {
 		t.Error("JWE with an unprotected nonce parsed as valid.")
@@ -191,15 +191,15 @@ func TestRejectUnprotectedJWENonce(t *testing.T) {
 
 	// Full JSON
 	input = `{
-      "header":  { "alg": "XYZ", "enc": "XYZ" },
-      "aad": "does-not-matter",
-      "iv": "does-not-matter",
-      "ciphertext": "does-not-matter",
-      "tag": "does-not-matter",
-      "recipients": [{
-        "header": { "nonce": "should-cause-an-error" },
-        "encrypted_key": "does-not-matter"
-      }]
+		"header":  { "alg": "XYZ", "enc": "XYZ" },
+		"aad": "does-not-matter",
+		"iv": "does-not-matter",
+		"ciphertext": "does-not-matter",
+		"tag": "does-not-matter",
+		"recipients": [{
+			"header": { "nonce": "should-cause-an-error" },
+			"encrypted_key": "does-not-matter"
+		}]
 	}`
 	_, err = ParseEncrypted(input)
 	if err == nil {

--- a/jws.go
+++ b/jws.go
@@ -70,8 +70,8 @@ func ParseSigned(input string) (*JsonWebSignature, error) {
 // Get a header value
 func (sig Signature) mergedHeaders() rawHeader {
 	out := rawHeader{}
-	out.merge(sig.protected)
-	out.merge(sig.header)
+	out.merge(sig.protected, true)
+	out.merge(sig.header, false)
 	return out
 }
 

--- a/jws.go
+++ b/jws.go
@@ -70,8 +70,8 @@ func ParseSigned(input string) (*JsonWebSignature, error) {
 // Get a header value
 func (sig Signature) mergedHeaders() rawHeader {
 	out := rawHeader{}
-	out.merge(sig.protected, true)
-	out.merge(sig.header, false)
+	out.merge(sig.protected)
+	out.merge(sig.header)
 	return out
 }
 
@@ -125,6 +125,10 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 			}
 		}
 
+		if parsed.Header != nil && parsed.Header.Nonce != "" {
+			return nil, fmt.Errorf("square/go-jose: Nonce parameter included in unprotected header")
+		}
+
 		signature.header = parsed.Header
 		signature.Signature = parsed.Signature.bytes()
 		// Make a fake "original" rawSignatureInfo to store the unprocessed
@@ -153,6 +157,11 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 			if err != nil {
 				return nil, err
 			}
+		}
+
+		// Check that there is not a nonce in the unprotected header
+		if sig.Header != nil && sig.Header.Nonce != "" {
+			return nil, fmt.Errorf("square/go-jose: Nonce parameter included in unprotected header")
 		}
 
 		obj.Signatures[i].Signature = sig.Signature.bytes()

--- a/jws.go
+++ b/jws.go
@@ -106,7 +106,7 @@ func parseSignedFull(input string) (*JsonWebSignature, error) {
 // sanitized produces a cleaned-up JWS object from the raw JSON.
 func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 	if parsed.Payload == nil {
-		return nil, fmt.Errorf("square/go-jose: missing payload in JWS message")
+		return nil, ErrUnprotectedNonce
 	}
 
 	obj := &JsonWebSignature{
@@ -126,7 +126,7 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 		}
 
 		if parsed.Header != nil && parsed.Header.Nonce != "" {
-			return nil, fmt.Errorf("square/go-jose: Nonce parameter included in unprotected header")
+			return nil, ErrUnprotectedNonce
 		}
 
 		signature.header = parsed.Header
@@ -161,7 +161,7 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 
 		// Check that there is not a nonce in the unprotected header
 		if sig.Header != nil && sig.Header.Nonce != "" {
-			return nil, fmt.Errorf("square/go-jose: Nonce parameter included in unprotected header")
+			return nil, ErrUnprotectedNonce
 		}
 
 		obj.Signatures[i].Signature = sig.Signature.bytes()

--- a/jws_test.go
+++ b/jws_test.go
@@ -95,29 +95,29 @@ func TestRejectUnprotectedJWSNonce(t *testing.T) {
 
 	// Flattened JSON
 	input := `{
-      "header": { "nonce": "should-cause-an-error" },
-			"payload": "does-not-matter",
-			"signature": "does-not-matter"
+		"header": { "nonce": "should-cause-an-error" },
+		"payload": "does-not-matter",
+		"signature": "does-not-matter"
 	}`
 	_, err := ParseSigned(input)
 	if err == nil {
 		t.Error("JWS with an unprotected nonce parsed as valid.")
-	} else if err.Error() != "square/go-jose: Nonce parameter included in unprotected header" {
+	} else if err != ErrUnprotectedNonce {
 		t.Errorf("Improper error for unprotected nonce: %v", err)
 	}
 
 	// Full JSON
 	input = `{
-			"payload": "does-not-matter",
-      "signatures": [{
-        "header": { "nonce": "should-cause-an-error" },
-			  "signature": "does-not-matter"
-      }]
+		"payload": "does-not-matter",
+ 		"signatures": [{
+ 			"header": { "nonce": "should-cause-an-error" },
+			"signature": "does-not-matter"
+		}]
 	}`
 	_, err = ParseSigned(input)
 	if err == nil {
 		t.Error("JWS with an unprotected nonce parsed as valid.")
-	} else if err.Error() != "square/go-jose: Nonce parameter included in unprotected header" {
+	} else if err != ErrUnprotectedNonce {
 		t.Errorf("Improper error for unprotected nonce: %v", err)
 	}
 }

--- a/jws_test.go
+++ b/jws_test.go
@@ -90,6 +90,38 @@ func TestFullParseJWS(t *testing.T) {
 	}
 }
 
+func TestRejectUnprotectedJWSNonce(t *testing.T) {
+	// No need to test compact, since that's always protected
+
+	// Flattened JSON
+	input := `{
+      "header": { "nonce": "should-cause-an-error" },
+			"payload": "does-not-matter",
+			"signature": "does-not-matter"
+	}`
+	_, err := ParseSigned(input)
+	if err == nil {
+		t.Error("JWS with an unprotected nonce parsed as valid.")
+	} else if err.Error() != "square/go-jose: Nonce parameter included in unprotected header" {
+		t.Errorf("Improper error for unprotected nonce: %v", err)
+	}
+
+	// Full JSON
+	input = `{
+			"payload": "does-not-matter",
+      "signatures": [{
+        "header": { "nonce": "should-cause-an-error" },
+			  "signature": "does-not-matter"
+      }]
+	}`
+	_, err = ParseSigned(input)
+	if err == nil {
+		t.Error("JWS with an unprotected nonce parsed as valid.")
+	} else if err.Error() != "square/go-jose: Nonce parameter included in unprotected header" {
+		t.Errorf("Improper error for unprotected nonce: %v", err)
+	}
+}
+
 func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 	input := `{
 			"header": {
@@ -98,8 +130,7 @@ func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 							"e": "AQAB",
 							"kty": "RSA",
 							"n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_pSUHWXNmS9R4NZ3t2fQAzPeW7jOfF0LKuJRGkekx6tXP1uSnNibgpJULNc4208dgBaCHo3mvaE2HV2GmVl1yxwWX5QZZkGQGjNDZYnjFfa2DKVvFs0QbAk21ROm594kAxlRlMMrvqlf24Eq4ERO0ptzpZgm_3j_e4hGRD39gJS7kAzK-j2cacFQ5Qi2Y6wZI2p-FCq_wiYsfEAIkATPBiLKl_6d_Jfcvs_impcXQ"
-					},
-          "nonce": "should_not_be_reflected"
+					}
 			},
 			"payload": "Zm9vCg",
 			"signature": "hRt2eYqBd_MyMRNIh8PEIACoFtmBi7BHTLBaAhpSU6zyDAFdEBaX7us4VB9Vo1afOL03Q8iuoRA0AT4akdV_mQTAQ_jhTcVOAeXPr0tB8b8Q11UPQ0tXJYmU4spAW2SapJIvO50ntUaqU05kZd0qw8-noH1Lja-aNnU-tQII4iYVvlTiRJ5g8_CADsvJqOk6FcHuo2mG643TRnhkAxUtazvHyIHeXMxydMMSrpwUwzMtln4ZJYBNx4QGEq6OhpAD_VSp-w8Lq5HOwGQoNs0bPxH1SGrArt67LFQBfjlVr94E1sn26p4vigXm83nJdNhWAMHHE9iV67xN-r29LT-FjA"
@@ -122,11 +153,6 @@ func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 	}
 	if string(payload) != "foo\n" {
 		t.Error(fmt.Sprintf("Payload was incorrect: '%s' should have been 'foo\\n'", string(payload)))
-	}
-
-	// Verify that the nonce included in the unprotected header was not reflected in the parsed object
-	if sig.Header.Nonce != "" {
-		t.Error(fmt.Sprintf("JWS allowed unprotected nonce: [%s]", sig.Header.Nonce))
 	}
 }
 

--- a/jws_test.go
+++ b/jws_test.go
@@ -98,7 +98,8 @@ func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 							"e": "AQAB",
 							"kty": "RSA",
 							"n": "tSwgy3ORGvc7YJI9B2qqkelZRUC6F1S5NwXFvM4w5-M0TsxbFsH5UH6adigV0jzsDJ5imAechcSoOhAh9POceCbPN1sTNwLpNbOLiQQ7RD5mY_pSUHWXNmS9R4NZ3t2fQAzPeW7jOfF0LKuJRGkekx6tXP1uSnNibgpJULNc4208dgBaCHo3mvaE2HV2GmVl1yxwWX5QZZkGQGjNDZYnjFfa2DKVvFs0QbAk21ROm594kAxlRlMMrvqlf24Eq4ERO0ptzpZgm_3j_e4hGRD39gJS7kAzK-j2cacFQ5Qi2Y6wZI2p-FCq_wiYsfEAIkATPBiLKl_6d_Jfcvs_impcXQ"
-					}
+					},
+          "nonce": "should_not_be_reflected"
 			},
 			"payload": "Zm9vCg",
 			"signature": "hRt2eYqBd_MyMRNIh8PEIACoFtmBi7BHTLBaAhpSU6zyDAFdEBaX7us4VB9Vo1afOL03Q8iuoRA0AT4akdV_mQTAQ_jhTcVOAeXPr0tB8b8Q11UPQ0tXJYmU4spAW2SapJIvO50ntUaqU05kZd0qw8-noH1Lja-aNnU-tQII4iYVvlTiRJ5g8_CADsvJqOk6FcHuo2mG643TRnhkAxUtazvHyIHeXMxydMMSrpwUwzMtln4ZJYBNx4QGEq6OhpAD_VSp-w8Lq5HOwGQoNs0bPxH1SGrArt67LFQBfjlVr94E1sn26p4vigXm83nJdNhWAMHHE9iV67xN-r29LT-FjA"
@@ -121,6 +122,11 @@ func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 	}
 	if string(payload) != "foo\n" {
 		t.Error(fmt.Sprintf("Payload was incorrect: '%s' should have been 'foo\\n'", string(payload)))
+	}
+
+	// Verify that the nonce included in the unprotected header was not reflected in the parsed object
+	if sig.Header.Nonce != "" {
+		t.Error(fmt.Sprintf("JWS allowed unprotected nonce: [%s]", sig.Header.Nonce))
 	}
 }
 

--- a/shared.go
+++ b/shared.go
@@ -112,17 +112,18 @@ const (
 
 // rawHeader represents the JOSE header for JWE/JWS objects (used for parsing).
 type rawHeader struct {
-	Alg  string               `json:"alg,omitempty"`
-	Enc  ContentEncryption    `json:"enc,omitempty"`
-	Zip  CompressionAlgorithm `json:"zip,omitempty"`
-	Crit []string             `json:"crit,omitempty"`
-	Apu  *byteBuffer          `json:"apu,omitempty"`
-	Apv  *byteBuffer          `json:"apv,omitempty"`
-	Epk  *JsonWebKey          `json:"epk,omitempty"`
-	Iv   *byteBuffer          `json:"iv,omitempty"`
-	Tag  *byteBuffer          `json:"tag,omitempty"`
-	Jwk  *JsonWebKey          `json:"jwk,omitempty"`
-	Kid  string               `json:"kid,omitempty"`
+	Alg   string               `json:"alg,omitempty"`
+	Enc   ContentEncryption    `json:"enc,omitempty"`
+	Zip   CompressionAlgorithm `json:"zip,omitempty"`
+	Crit  []string             `json:"crit,omitempty"`
+	Apu   *byteBuffer          `json:"apu,omitempty"`
+	Apv   *byteBuffer          `json:"apv,omitempty"`
+	Epk   *JsonWebKey          `json:"epk,omitempty"`
+	Iv    *byteBuffer          `json:"iv,omitempty"`
+	Tag   *byteBuffer          `json:"tag,omitempty"`
+	Jwk   *JsonWebKey          `json:"jwk,omitempty"`
+	Kid   string               `json:"kid,omitempty"`
+	Nonce string               `json:"nonce,omitempty"`
 }
 
 // JoseHeader represents the read-only JOSE header for JWE/JWS objects.
@@ -130,6 +131,7 @@ type JoseHeader struct {
 	KeyID      string
 	JsonWebKey *JsonWebKey
 	Algorithm  string
+	Nonce      string
 }
 
 // sanitized produces a cleaned-up header object from the raw JSON.
@@ -138,11 +140,12 @@ func (parsed rawHeader) sanitized() JoseHeader {
 		KeyID:      parsed.Kid,
 		JsonWebKey: parsed.Jwk,
 		Algorithm:  parsed.Alg,
+		Nonce:      parsed.Nonce,
 	}
 }
 
 // Merge headers from src into dst, giving precedence to headers from l.
-func (dst *rawHeader) merge(src *rawHeader) {
+func (dst *rawHeader) merge(src *rawHeader, protected bool) {
 	if src == nil {
 		return
 	}
@@ -182,6 +185,13 @@ func (dst *rawHeader) merge(src *rawHeader) {
 	}
 	if dst.Jwk == nil {
 		dst.Jwk = src.Jwk
+	}
+
+	// Fields handled within this block are ignored in unprotected headers
+	if protected {
+		if dst.Nonce == "" {
+			dst.Nonce = src.Nonce
+		}
 	}
 }
 

--- a/shared.go
+++ b/shared.go
@@ -55,6 +55,10 @@ var (
 	// trying to compact-serialize an object which can't be represented in
 	// compact form.
 	ErrNotSupported = errors.New("square/go-jose: compact serialization not supported for object")
+
+	// ErrUnprotectedNonce indicates that while parsing a JWS or JWE object, a
+	// nonce header parameter was included in an unprotected header object.
+	ErrUnprotectedNonce = errors.New("square/go-jose: Nonce parameter included in unprotected header")
 )
 
 // Key management algorithms

--- a/shared.go
+++ b/shared.go
@@ -145,7 +145,7 @@ func (parsed rawHeader) sanitized() JoseHeader {
 }
 
 // Merge headers from src into dst, giving precedence to headers from l.
-func (dst *rawHeader) merge(src *rawHeader, protected bool) {
+func (dst *rawHeader) merge(src *rawHeader) {
 	if src == nil {
 		return
 	}
@@ -186,12 +186,8 @@ func (dst *rawHeader) merge(src *rawHeader, protected bool) {
 	if dst.Jwk == nil {
 		dst.Jwk = src.Jwk
 	}
-
-	// Fields handled within this block are ignored in unprotected headers
-	if protected {
-		if dst.Nonce == "" {
-			dst.Nonce = src.Nonce
-		}
+	if dst.Nonce == "" {
+		dst.Nonce = src.Nonce
 	}
 }
 

--- a/signing.go
+++ b/signing.go
@@ -22,16 +22,21 @@ import (
 	"fmt"
 )
 
+// NonceSource represents a source of random nonces to go into JWS objects
+type NonceSource interface {
+	Nonce() (string, error)
+}
+
 // Signer represents a signer which takes a payload and produces a signed JWS object.
 type Signer interface {
 	Sign(payload []byte) (*JsonWebSignature, error)
-	AddNonces(nonces []string)
+	AddNonceSource(source NonceSource)
 }
 
 // MultiSigner represents a signer which supports multiple recipients.
 type MultiSigner interface {
 	Sign(payload []byte) (*JsonWebSignature, error)
-	AddNonces(nonces []string)
+	AddNonceSource(source NonceSource)
 	AddRecipient(alg SignatureAlgorithm, signingKey interface{}) error
 }
 
@@ -44,8 +49,8 @@ type payloadVerifier interface {
 }
 
 type genericSigner struct {
-	recipients []recipientSigInfo
-	nonces     []string
+	recipients  []recipientSigInfo
+	nonceSource NonceSource
 }
 
 type recipientSigInfo struct {
@@ -141,13 +146,12 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 			protected.Kid = recipient.publicKey.KeyID
 		}
 
-		if ctx.nonces != nil {
-			if len(ctx.nonces) == 0 {
-				return nil, fmt.Errorf("square/go-jose: Nonce required but no nonces available")
+		if ctx.nonceSource != nil {
+			nonce, err := ctx.nonceSource.Nonce()
+			if err != nil {
+				return nil, fmt.Errorf("square/go-jose: Error generating nonce: %v", err)
 			}
-
-			protected.Nonce = ctx.nonces[0]
-			ctx.nonces = ctx.nonces[1:]
+			protected.Nonce = nonce
 		}
 
 		serializedProtected := mustSerializeJSON(protected)
@@ -168,11 +172,11 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 	return obj, nil
 }
 
-// AddNonces provides or updates a nonce pool to the first recipients.
+// AddNonceSource provides or updates a nonce pool to the first recipients.
 // After this method is called, the signer will consume one nonce per
-// signature, returning an error if there are no nonces left in the pool.
-func (ctx *genericSigner) AddNonces(nonces []string) {
-	ctx.nonces = append(ctx.nonces, nonces...)
+// signature, returning an error it is unable to get a nonce.
+func (ctx *genericSigner) AddNonceSource(source NonceSource) {
+	ctx.nonceSource = source
 }
 
 // Verify validates the signature on the object and returns the payload.

--- a/signing.go
+++ b/signing.go
@@ -25,11 +25,13 @@ import (
 // Signer represents a signer which takes a payload and produces a signed JWS object.
 type Signer interface {
 	Sign(payload []byte) (*JsonWebSignature, error)
+	AddNonces(nonces []string)
 }
 
 // MultiSigner represents a signer which supports multiple recipients.
 type MultiSigner interface {
 	Sign(payload []byte) (*JsonWebSignature, error)
+	AddNonces(nonces []string)
 	AddRecipient(alg SignatureAlgorithm, signingKey interface{}) error
 }
 
@@ -43,6 +45,7 @@ type payloadVerifier interface {
 
 type genericSigner struct {
 	recipients []recipientSigInfo
+	nonces     []string
 }
 
 type recipientSigInfo struct {
@@ -138,6 +141,15 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 			protected.Kid = recipient.publicKey.KeyID
 		}
 
+		if ctx.nonces != nil {
+			if len(ctx.nonces) == 0 {
+				return nil, fmt.Errorf("square/go-jose: Nonce required but no nonces available")
+			}
+
+			protected.Nonce = ctx.nonces[0]
+			ctx.nonces = ctx.nonces[1:]
+		}
+
 		serializedProtected := mustSerializeJSON(protected)
 
 		input := []byte(fmt.Sprintf("%s.%s",
@@ -154,6 +166,13 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 	}
 
 	return obj, nil
+}
+
+// AddNonces provides or updates a nonce pool to the first recipients.
+// After this method is called, the signer will consume one nonce per
+// signature, returning an error if there are no nonces left in the pool.
+func (ctx *genericSigner) AddNonces(nonces []string) {
+	ctx.nonces = append(ctx.nonces, nonces...)
 }
 
 // Verify validates the signature on the object and returns the payload.

--- a/signing.go
+++ b/signing.go
@@ -30,13 +30,13 @@ type NonceSource interface {
 // Signer represents a signer which takes a payload and produces a signed JWS object.
 type Signer interface {
 	Sign(payload []byte) (*JsonWebSignature, error)
-	AddNonceSource(source NonceSource)
+	SetNonceSource(source NonceSource)
 }
 
 // MultiSigner represents a signer which supports multiple recipients.
 type MultiSigner interface {
 	Sign(payload []byte) (*JsonWebSignature, error)
-	AddNonceSource(source NonceSource)
+	SetNonceSource(source NonceSource)
 	AddRecipient(alg SignatureAlgorithm, signingKey interface{}) error
 }
 
@@ -172,10 +172,10 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 	return obj, nil
 }
 
-// AddNonceSource provides or updates a nonce pool to the first recipients.
+// SetNonceSource provides or updates a nonce pool to the first recipients.
 // After this method is called, the signer will consume one nonce per
 // signature, returning an error it is unable to get a nonce.
-func (ctx *genericSigner) AddNonceSource(source NonceSource) {
+func (ctx *genericSigner) SetNonceSource(source NonceSource) {
 	ctx.nonceSource = source
 }
 

--- a/signing_test.go
+++ b/signing_test.go
@@ -40,7 +40,7 @@ func RoundtripJWS(sigAlg SignatureAlgorithm, serializer func(*JsonWebSignature) 
 	}
 
 	if nonce != "" {
-		signer.AddNonceSource(staticNonceSource(nonce))
+		signer.SetNonceSource(staticNonceSource(nonce))
 	}
 
 	input := []byte("Lorem ipsum dolor sit amet")

--- a/signing_test.go
+++ b/signing_test.go
@@ -27,6 +27,12 @@ import (
 	"testing"
 )
 
+type staticNonceSource string
+
+func (sns staticNonceSource) Nonce() (string, error) {
+	return string(sns), nil
+}
+
 func RoundtripJWS(sigAlg SignatureAlgorithm, serializer func(*JsonWebSignature) (string, error), corrupter func(*JsonWebSignature), signingKey interface{}, verificationKey interface{}, nonce string) error {
 	signer, err := NewSigner(sigAlg, signingKey)
 	if err != nil {
@@ -34,7 +40,7 @@ func RoundtripJWS(sigAlg SignatureAlgorithm, serializer func(*JsonWebSignature) 
 	}
 
 	if nonce != "" {
-		signer.AddNonces([]string{nonce})
+		signer.AddNonceSource(staticNonceSource(nonce))
 	}
 
 	input := []byte("Lorem ipsum dolor sit amet")


### PR DESCRIPTION
ACME defines a 'nonce' header parameter for JWS, which must only be sent in a protected header.  This PR makes the following changes:

* A `Nonce` field to `JoseHeader` to expose nonce values from parsed objects
* A `AddNonces` method to signers to enable sending of nonces
* Checks for unprotected nonces in parsing code
* Tests that verify that the nonces are parsed and checked correctly
