### PR TITLE
Support symmetric keys in JWK and support JWK for encrypters

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,15 @@ has a list of constants.
 
 See below for a table of supported key types. These are understood by the
 library, and can be passed to corresponding functions such as `NewEncrypter` or
-`NewSigner`.
+`NewSigner`. Note that if you are creating a new encrypter or signer with a
+JsonWebKey, the key id of the JsonWebKey (if present) will be added to any
+resulting messages.
 
  Algorithm(s)               | Corresponding types
  :------------------------- | -------------------------------
- RSA                        | *[rsa.PublicKey](http://golang.org/pkg/crypto/rsa/#PublicKey), *[rsa.PrivateKey](http://golang.org/pkg/crypto/rsa/#PrivateKey)
- ECDH, ECDSA                | *[ecdsa.PublicKey](http://golang.org/pkg/crypto/ecdsa/#PublicKey), *[ecdsa.PrivateKey](http://golang.org/pkg/crypto/ecdsa/#PrivateKey)
- AES, HMAC                  | []byte
+ RSA                        | *[rsa.PublicKey](http://golang.org/pkg/crypto/rsa/#PublicKey), *[rsa.PrivateKey](http://golang.org/pkg/crypto/rsa/#PrivateKey), *[jose.JsonWebKey](https://godoc.org/github.com/square/go-jose#JsonWebKey)
+ ECDH, ECDSA                | *[ecdsa.PublicKey](http://golang.org/pkg/crypto/ecdsa/#PublicKey), *[ecdsa.PrivateKey](http://golang.org/pkg/crypto/ecdsa/#PrivateKey), *[jose.JsonWebKey](https://godoc.org/github.com/square/go-jose#JsonWebKey)
+ AES, HMAC                  | []byte, *[jose.JsonWebKey](https://godoc.org/github.com/square/go-jose#JsonWebKey)
 
 ## Examples
 

--- a/crypter.go
+++ b/crypter.go
@@ -71,6 +71,7 @@ type genericEncrypter struct {
 }
 
 type recipientKeyInfo struct {
+	keyID        string
 	keyAlg       KeyAlgorithm
 	keyEncrypter keyEncrypter
 }
@@ -93,30 +94,46 @@ func NewEncrypter(alg KeyAlgorithm, enc ContentEncryption, encryptionKey interfa
 		return nil, ErrUnsupportedAlgorithm
 	}
 
+	var keyID string
+	var rawKey interface{}
+	switch encryptionKey := encryptionKey.(type) {
+	case *JsonWebKey:
+		keyID = encryptionKey.KeyID
+		rawKey = encryptionKey.Key
+	default:
+		rawKey = encryptionKey
+	}
+
 	switch alg {
 	case DIRECT:
 		// Direct encryption mode must be treated differently
-		if reflect.TypeOf(encryptionKey) != reflect.TypeOf([]byte{}) {
+		if reflect.TypeOf(rawKey) != reflect.TypeOf([]byte{}) {
 			return nil, ErrUnsupportedKeyType
 		}
 		encrypter.keyGenerator = staticKeyGenerator{
-			key: encryptionKey.([]byte),
+			key: rawKey.([]byte),
 		}
-		recipient, _ := newSymmetricRecipient(alg, encryptionKey.([]byte))
+		recipient, _ := newSymmetricRecipient(alg, rawKey.([]byte))
+		if keyID != "" {
+			recipient.keyID = keyID
+		}
 		encrypter.recipients = []recipientKeyInfo{recipient}
 		return encrypter, nil
 	case ECDH_ES:
 		// ECDH-ES (w/o key wrapping) is similar to DIRECT mode
-		typeOf := reflect.TypeOf(encryptionKey)
+		typeOf := reflect.TypeOf(rawKey)
 		if typeOf != reflect.TypeOf(&ecdsa.PublicKey{}) {
 			return nil, ErrUnsupportedKeyType
 		}
 		encrypter.keyGenerator = ecKeyGenerator{
 			size:      encrypter.cipher.keySize(),
 			algID:     string(enc),
-			publicKey: encryptionKey.(*ecdsa.PublicKey),
+			publicKey: rawKey.(*ecdsa.PublicKey),
 		}
-		recipient, _ := newECDHRecipient(alg, encryptionKey.(*ecdsa.PublicKey))
+		recipient, _ := newECDHRecipient(alg, rawKey.(*ecdsa.PublicKey))
+		if keyID != "" {
+			recipient.keyID = keyID
+		}
 		encrypter.recipients = []recipientKeyInfo{recipient}
 		return encrypter, nil
 	default:
@@ -158,21 +175,31 @@ func (ctx *genericEncrypter) AddRecipient(alg KeyAlgorithm, encryptionKey interf
 		return fmt.Errorf("square/go-jose: key algorithm '%s' not supported in multi-recipient mode", alg)
 	}
 
-	switch encryptionKey := encryptionKey.(type) {
-	case *rsa.PublicKey:
-		recipient, err = newRSARecipient(alg, encryptionKey)
-	case []byte:
-		recipient, err = newSymmetricRecipient(alg, encryptionKey)
-	case *ecdsa.PublicKey:
-		recipient, err = newECDHRecipient(alg, encryptionKey)
-	default:
-		return ErrUnsupportedKeyType
-	}
+	recipient, err = makeJWERecipient(alg, encryptionKey)
 
 	if err == nil {
 		ctx.recipients = append(ctx.recipients, recipient)
 	}
 	return err
+}
+
+func makeJWERecipient(alg KeyAlgorithm, encryptionKey interface{}) (recipientKeyInfo, error) {
+	switch encryptionKey := encryptionKey.(type) {
+	case *rsa.PublicKey:
+		return newRSARecipient(alg, encryptionKey)
+	case *ecdsa.PublicKey:
+		return newECDHRecipient(alg, encryptionKey)
+	case []byte:
+		return newSymmetricRecipient(alg, encryptionKey)
+	case *JsonWebKey:
+		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
+		if err == nil && encryptionKey.KeyID != "" {
+			recipient.keyID = encryptionKey.KeyID
+		}
+		return recipient, err
+	default:
+		return recipientKeyInfo{}, ErrUnsupportedKeyType
+	}
 }
 
 // newDecrypter creates an appropriate decrypter based on the key type
@@ -228,6 +255,9 @@ func (ctx *genericEncrypter) EncryptWithAuthData(plaintext, aad []byte) (*JsonWe
 		}
 
 		recipient.header.Alg = string(info.keyAlg)
+		if info.keyID != "" {
+			recipient.header.Kid = info.keyID
+		}
 		obj.recipients[i] = recipient
 	}
 

--- a/crypter.go
+++ b/crypter.go
@@ -217,6 +217,8 @@ func newDecrypter(decryptionKey interface{}) (keyDecrypter, error) {
 		return &symmetricKeyCipher{
 			key: decryptionKey,
 		}, nil
+	case *JsonWebKey:
+		return newDecrypter(decryptionKey.Key)
 	default:
 		return nil, ErrUnsupportedKeyType
 	}

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -185,6 +185,32 @@ func TestRoundtripsJWECorrupted(t *testing.T) {
 	}
 }
 
+func TestEncrypterWithJWKAndKeyID(t *testing.T) {
+	enc, err := NewEncrypter(A128KW, A128GCM, &JsonWebKey{
+		KeyType: "oct",
+		KeyID:   "test-id",
+		Key:     []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	ciphertext, _ := enc.Encrypt([]byte("Lorem ipsum dolor sit amet"))
+
+	serialized1, _ := ciphertext.CompactSerialize()
+	serialized2 := ciphertext.FullSerialize()
+
+	parsed1, _ := ParseEncrypted(serialized1)
+	parsed2, _ := ParseEncrypted(serialized2)
+
+	if parsed1.Header.KeyID != "test-id" {
+		t.Errorf("expected message to have key id from JWK, but found '%s' instead", parsed1.Header.KeyID)
+	}
+	if parsed2.Header.KeyID != "test-id" {
+		t.Errorf("expected message to have key id from JWK, but found '%s' instead", parsed2.Header.KeyID)
+	}
+}
+
 func TestEncrypterWithBrokenRand(t *testing.T) {
 	keyAlgs := []KeyAlgorithm{ECDH_ES_A128KW, A128KW, RSA1_5, RSA_OAEP, RSA_OAEP_256, A128GCMKW}
 	encAlgs := []ContentEncryption{A128GCM, A192GCM, A256GCM, A128CBC_HS256, A192CBC_HS384, A256CBC_HS512}

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -187,9 +187,8 @@ func TestRoundtripsJWECorrupted(t *testing.T) {
 
 func TestEncrypterWithJWKAndKeyID(t *testing.T) {
 	enc, err := NewEncrypter(A128KW, A128GCM, &JsonWebKey{
-		KeyType: "oct",
-		KeyID:   "test-id",
-		Key:     []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+		KeyID: "test-id",
+		Key:   []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
 	})
 	if err != nil {
 		t.Error(err)
@@ -366,8 +365,8 @@ func symmetricTestKey(size int) []testKey {
 			dec: key,
 		},
 		testKey{
-			enc: &JsonWebKey{KeyType: "oct", KeyID: "test", Key: key},
-			dec: &JsonWebKey{KeyType: "oct", KeyID: "test", Key: key},
+			enc: &JsonWebKey{KeyID: "test", Key: key},
+			dec: &JsonWebKey{KeyID: "test", Key: key},
 		},
 	}
 }
@@ -391,8 +390,8 @@ func generateTestKeys(keyAlg KeyAlgorithm, encAlg ContentEncryption) []testKey {
 				enc: &ecTestKey521.PublicKey,
 			},
 			testKey{
-				dec: &JsonWebKey{KeyType: "EC", KeyID: "test", Key: ecTestKey256},
-				enc: &JsonWebKey{KeyType: "EC", KeyID: "test", Key: &ecTestKey256.PublicKey},
+				dec: &JsonWebKey{KeyID: "test", Key: ecTestKey256},
+				enc: &JsonWebKey{KeyID: "test", Key: &ecTestKey256.PublicKey},
 			},
 		}
 	case A128GCMKW, A128KW:

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -365,6 +365,10 @@ func symmetricTestKey(size int) []testKey {
 			enc: key,
 			dec: key,
 		},
+		testKey{
+			enc: &JsonWebKey{KeyType: "oct", KeyID: "test", Key: key},
+			dec: &JsonWebKey{KeyType: "oct", KeyID: "test", Key: key},
+		},
 	}
 }
 
@@ -385,6 +389,10 @@ func generateTestKeys(keyAlg KeyAlgorithm, encAlg ContentEncryption) []testKey {
 			testKey{
 				dec: ecTestKey521,
 				enc: &ecTestKey521.PublicKey,
+			},
+			testKey{
+				dec: &JsonWebKey{KeyType: "EC", KeyID: "test", Key: ecTestKey256},
+				enc: &JsonWebKey{KeyType: "EC", KeyID: "test", Key: &ecTestKey256.PublicKey},
 			},
 		}
 	case A128GCMKW, A128KW:

--- a/jwe.go
+++ b/jwe.go
@@ -127,8 +127,6 @@ func (parsed *rawJsonWebEncryption) sanitized() (*JsonWebEncryption, error) {
 		unprotected: parsed.Unprotected,
 	}
 
-	obj.Header = obj.mergedHeaders(nil).sanitized()
-
 	// Check that there is not a nonce in the unprotected headers
 	if (parsed.Unprotected != nil && parsed.Unprotected.Nonce != "") ||
 		(parsed.Header != nil && parsed.Header.Nonce != "") {
@@ -141,6 +139,10 @@ func (parsed *rawJsonWebEncryption) sanitized() (*JsonWebEncryption, error) {
 			return nil, fmt.Errorf("square/go-jose: invalid protected header: %s, %s", err, parsed.Protected.base64())
 		}
 	}
+
+	// Note: this must be called _after_ we parse the protected header,
+	// otherwise fields from the protected header will not get picked up.
+	obj.Header = obj.mergedHeaders(nil).sanitized()
 
 	if len(parsed.Recipients) == 0 {
 		obj.recipients = []recipientInfo{

--- a/jwk.go
+++ b/jwk.go
@@ -55,7 +55,6 @@ type rawJsonWebKey struct {
 // JsonWebKey represents a public or private key in JWK format.
 type JsonWebKey struct {
 	Key       interface{}
-	KeyType   string
 	KeyID     string
 	Algorithm string
 	Use       string
@@ -121,7 +120,7 @@ func (k *JsonWebKey) UnmarshalJSON(data []byte) (err error) {
 	}
 
 	if err == nil {
-		*k = JsonWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use, KeyType: raw.Kty}
+		*k = JsonWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use}
 	}
 	return
 }

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -521,9 +521,6 @@ func TestJWKSymmetricKey(t *testing.T) {
 	var jwk1 JsonWebKey
 	json.Unmarshal([]byte(sample1), &jwk1)
 
-	if jwk1.KeyType != "oct" {
-		t.Errorf("expected KeyType to be oct, but was '%s'", jwk1.KeyType)
-	}
 	if jwk1.Algorithm != "A128KW" {
 		t.Errorf("expected Algorithm to be A128KW, but was '%s'", jwk1.Algorithm)
 	}
@@ -535,9 +532,6 @@ func TestJWKSymmetricKey(t *testing.T) {
 	var jwk2 JsonWebKey
 	json.Unmarshal([]byte(sample2), &jwk2)
 
-	if jwk2.KeyType != "oct" {
-		t.Errorf("expected KeyType to be oct, but was '%s'", jwk2.KeyType)
-	}
 	if jwk2.KeyID != "HMAC key used in JWS spec Appendix A.1 example" {
 		t.Errorf("expected KeyID to be 'HMAC key used in JWS spec Appendix A.1 example', but was '%s'", jwk2.KeyID)
 	}
@@ -550,7 +544,7 @@ func TestJWKSymmetricKey(t *testing.T) {
 }
 
 func TestJWKSymmetricRoundtrip(t *testing.T) {
-	jwk1 := JsonWebKey{KeyType: "oct", Key: []byte{1, 2, 3, 4}}
+	jwk1 := JsonWebKey{Key: []byte{1, 2, 3, 4}}
 	marshaled, err := jwk1.MarshalJSON()
 	if err != nil {
 		t.Errorf("failed to marshal valid JWK object", err)
@@ -562,16 +556,13 @@ func TestJWKSymmetricRoundtrip(t *testing.T) {
 		t.Errorf("failed to unmarshal valid JWK object", err)
 	}
 
-	if jwk1.KeyType != jwk2.KeyType {
-		t.Error("round-trip of symmetric JWK gave different key types")
-	}
 	if !bytes.Equal(jwk1.Key.([]byte), jwk2.Key.([]byte)) {
 		t.Error("round-trip of symmetric JWK gave different raw keys")
 	}
 }
 
 func TestJWKSymmetricInvalid(t *testing.T) {
-	invalid := JsonWebKey{KeyType: "oct"}
+	invalid := JsonWebKey{}
 	_, err := invalid.MarshalJSON()
 	if err == nil {
 		t.Error("excepted error on marshaling invalid symmetric JWK object")

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -548,3 +548,38 @@ func TestJWKSymmetricKey(t *testing.T) {
 		t.Errorf("expected Key to be '%s', but was '%s'", hex.EncodeToString(expected2), hex.EncodeToString(jwk2.Key.([]byte)))
 	}
 }
+
+func TestJWKSymmetricRoundtrip(t *testing.T) {
+	jwk1 := JsonWebKey{KeyType: "oct", Key: []byte{1, 2, 3, 4}}
+	marshaled, err := jwk1.MarshalJSON()
+	if err != nil {
+		t.Errorf("failed to marshal valid JWK object", err)
+	}
+
+	var jwk2 JsonWebKey
+	err = jwk2.UnmarshalJSON(marshaled)
+	if err != nil {
+		t.Errorf("failed to unmarshal valid JWK object", err)
+	}
+
+	if jwk1.KeyType != jwk2.KeyType {
+		t.Error("round-trip of symmetric JWK gave different key types")
+	}
+	if !bytes.Equal(jwk1.Key.([]byte), jwk2.Key.([]byte)) {
+		t.Error("round-trip of symmetric JWK gave different raw keys")
+	}
+}
+
+func TestJWKSymmetricInvalid(t *testing.T) {
+	invalid := JsonWebKey{KeyType: "oct"}
+	_, err := invalid.MarshalJSON()
+	if err == nil {
+		t.Error("excepted error on marshaling invalid symmetric JWK object")
+	}
+
+	var jwk JsonWebKey
+	err = jwk.UnmarshalJSON([]byte(`{"kty":"oct"}`))
+	if err == nil {
+		t.Error("excepted error on unmarshaling invalid symmetric JWK object")
+	}
+}

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -161,7 +161,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	kid := "DEADBEEF"
 
 	for i, key := range []interface{}{ecTestKey256, ecTestKey384, ecTestKey521, rsaTestKey} {
-		for _, use := range []string{ "", "sig", "enc" } {
+		for _, use := range []string{"", "sig", "enc"} {
 			jwk := JsonWebKey{Key: key, KeyID: kid, Algorithm: "foo"}
 			if use != "" {
 				jwk.Use = use
@@ -511,5 +511,40 @@ func TestJWKSetKey(t *testing.T) {
 	}
 	if k[0].KeyID != "ABCDEFG" {
 		t.Error("method should return key with ID ABCDEFG")
+	}
+}
+
+func TestJWKSymmetricKey(t *testing.T) {
+	sample1 := `{"kty":"oct","alg":"A128KW","k":"GawgguFyGrWKav7AX4VKUg"}`
+	sample2 := `{"kty":"oct","k":"AyM1SysPpbyDfgZld3umj1qzKObwVMkoqQ-EstJQLr_T-1qS0gZH75aKtMN3Yj0iPS4hcgUuTwjAzZr1Z9CAow","kid":"HMAC key used in JWS spec Appendix A.1 example"}`
+
+	var jwk1 JsonWebKey
+	json.Unmarshal([]byte(sample1), &jwk1)
+
+	if jwk1.KeyType != "oct" {
+		t.Errorf("expected KeyType to be oct, but was '%s'", jwk1.KeyType)
+	}
+	if jwk1.Algorithm != "A128KW" {
+		t.Errorf("expected Algorithm to be A128KW, but was '%s'", jwk1.Algorithm)
+	}
+	expected1 := fromHexBytes("19ac2082e1721ab58a6afec05f854a52")
+	if !bytes.Equal(jwk1.Key.([]byte), expected1) {
+		t.Errorf("expected Key to be '%s', but was '%s'", hex.EncodeToString(expected1), hex.EncodeToString(jwk1.Key.([]byte)))
+	}
+
+	var jwk2 JsonWebKey
+	json.Unmarshal([]byte(sample2), &jwk2)
+
+	if jwk2.KeyType != "oct" {
+		t.Errorf("expected KeyType to be oct, but was '%s'", jwk2.KeyType)
+	}
+	if jwk2.KeyID != "HMAC key used in JWS spec Appendix A.1 example" {
+		t.Errorf("expected KeyID to be 'HMAC key used in JWS spec Appendix A.1 example', but was '%s'", jwk2.KeyID)
+	}
+	expected2 := fromHexBytes(`
+    0323354b2b0fa5bc837e0665777ba68f5ab328e6f054c928a90f84b2d2502ebf
+    d3fb5a92d20647ef968ab4c377623d223d2e2172052e4f08c0cd9af567d080a3`)
+	if !bytes.Equal(jwk2.Key.([]byte), expected2) {
+		t.Errorf("expected Key to be '%s', but was '%s'", hex.EncodeToString(expected2), hex.EncodeToString(jwk2.Key.([]byte)))
 	}
 }

--- a/signing.go
+++ b/signing.go
@@ -102,7 +102,7 @@ func newVerifier(verificationKey interface{}) (payloadVerifier, error) {
 }
 
 func (ctx *genericSigner) AddRecipient(alg SignatureAlgorithm, signingKey interface{}) error {
-	recipient, err := makeRecipient(alg, signingKey)
+	recipient, err := makeJWSRecipient(alg, signingKey)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (ctx *genericSigner) AddRecipient(alg SignatureAlgorithm, signingKey interf
 	return nil
 }
 
-func makeRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipientSigInfo, error) {
+func makeJWSRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipientSigInfo, error) {
 	switch signingKey := signingKey.(type) {
 	case *rsa.PrivateKey:
 		return newRSASigner(alg, signingKey)
@@ -120,7 +120,7 @@ func makeRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipientSig
 	case []byte:
 		return newSymmetricSigner(alg, signingKey)
 	case *JsonWebKey:
-		recipient, err := makeRecipient(alg, signingKey.Key)
+		recipient, err := makeJWSRecipient(alg, signingKey.Key)
 		if err != nil {
 			return recipientSigInfo{}, err
 		}


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm @sqshh 
cc: @lusis

This pull request adds:
* Support for representing symmetric keys as a JsonWebKey
* Support for instantiating an encrypter given a JsonWebKey

This partially addresses #56, in that it allows for creating encrypters with custom key IDs.

For example:
```
crypter, err := NewEncrypter(A128KW, A128GCM, &JsonWebKey{
		KeyID:   "test-id",
		Key:     []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
	})
```
The above snippet would create an encrypter that adds the key ID "test-id" to any output message.