### PR TITLE
Reconcile with letsencrypt/go-jose

### DIFF
--- a/jwe.go
+++ b/jwe.go
@@ -227,7 +227,8 @@ func parseEncryptedCompact(input string) (*JsonWebEncryption, error) {
 
 // CompactSerialize serializes an object using the compact serialization format.
 func (obj JsonWebEncryption) CompactSerialize() (string, error) {
-	if len(obj.recipients) > 1 || obj.unprotected != nil || obj.recipients[0].header != nil {
+	if len(obj.recipients) != 1 || obj.unprotected != nil ||
+		obj.protected == nil || obj.recipients[0].header != nil {
 		return "", ErrNotSupported
 	}
 
@@ -268,7 +269,9 @@ func (obj JsonWebEncryption) FullSerialize() string {
 		raw.EncryptedKey = newBuffer(obj.recipients[0].encryptedKey)
 	}
 
-	raw.Protected = newBuffer(mustSerializeJSON(obj.protected))
+	if obj.protected != nil {
+		raw.Protected = newBuffer(mustSerializeJSON(obj.protected))
+	}
 
 	return string(mustSerializeJSON(raw))
 }

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -161,7 +161,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 	kid := "DEADBEEF"
 
 	for i, key := range []interface{}{ecTestKey256, ecTestKey384, ecTestKey521, rsaTestKey} {
-		for _, use := range []string{ "", "sig", "enc" } {
+		for _, use := range []string{"", "sig", "enc"} {
 			jwk := JsonWebKey{Key: key, KeyID: kid, Algorithm: "foo"}
 			if use != "" {
 				jwk.Use = use

--- a/jws.go
+++ b/jws.go
@@ -209,7 +209,7 @@ func parseSignedCompact(input string) (*JsonWebSignature, error) {
 
 // CompactSerialize serializes an object using the compact serialization format.
 func (obj JsonWebSignature) CompactSerialize() (string, error) {
-	if len(obj.Signatures) > 1 || obj.Signatures[0].header != nil {
+	if len(obj.Signatures) != 1 || obj.Signatures[0].header != nil || obj.Signatures[0].protected == nil {
 		return "", ErrNotSupported
 	}
 
@@ -229,19 +229,22 @@ func (obj JsonWebSignature) FullSerialize() string {
 	}
 
 	if len(obj.Signatures) == 1 {
-		serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
-		raw.Protected = newBuffer(serializedProtected)
+		if obj.Signatures[0].protected != nil {
+			serializedProtected := mustSerializeJSON(obj.Signatures[0].protected)
+			raw.Protected = newBuffer(serializedProtected)
+		}
 		raw.Header = obj.Signatures[0].header
 		raw.Signature = newBuffer(obj.Signatures[0].Signature)
 	} else {
 		raw.Signatures = make([]rawSignatureInfo, len(obj.Signatures))
 		for i, signature := range obj.Signatures {
-			serializedProtected := mustSerializeJSON(signature.protected)
-
 			raw.Signatures[i] = rawSignatureInfo{
-				Protected: newBuffer(serializedProtected),
 				Header:    signature.header,
 				Signature: newBuffer(signature.Signature),
+			}
+
+			if signature.protected != nil {
+				raw.Signatures[i].Protected = newBuffer(mustSerializeJSON(signature.protected))
 			}
 		}
 	}


### PR DESCRIPTION
There's only one significant change that has been added to letsencrypt/go-jose that we need to push upstream: A fix to not panic when processing a JWE or JWS without a protected header.

(`go fmt` also got rid of an extra space in `jwk_test.go`)