### PR TITLE
Squash remaining uses of json.Marshal

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -25,8 +25,6 @@ import (
 	"math/big"
 	"regexp"
 	"strings"
-
-	"github.com/square/go-jose/json"
 )
 
 var stripWhitespaceRegex = regexp.MustCompile("\\s")
@@ -47,13 +45,13 @@ func base64URLDecode(data string) ([]byte, error) {
 // Helper function to serialize known-good objects.
 // Precondition: value is not a nil pointer.
 func mustSerializeJSON(value interface{}) []byte {
-	out, err := json.Marshal(value)
+	out, err := MarshalJSON(value)
 	if err != nil {
 		panic(err)
 	}
 	// We never want to serialize the top-level value "null," since it's not a
 	// valid JOSE message. But if a caller passes in a nil pointer to this method,
-	// json.Marshal will happily serialize it as the top-level value "null". If
+	// MarshalJSON will happily serialize it as the top-level value "null". If
 	// that value is then embedded in another operation, for instance by being
 	// base64-encoded and fed as input to a signing algorithm
 	// (https://github.com/square/go-jose/issues/22), the result will be
@@ -148,7 +146,7 @@ func newBufferFromInt(num uint64) *byteBuffer {
 }
 
 func (b *byteBuffer) MarshalJSON() ([]byte, error) {
-	return json.Marshal(b.base64())
+	return MarshalJSON(b.base64())
 }
 
 func (b *byteBuffer) UnmarshalJSON(data []byte) error {

--- a/jwk.go
+++ b/jwk.go
@@ -25,8 +25,6 @@ import (
 	"math/big"
 	"reflect"
 	"strings"
-
-	"github.com/square/go-jose/json"
 )
 
 // rawJsonWebKey represents a public or private key in JWK format, used for parsing/serializing.
@@ -89,7 +87,7 @@ func (k JsonWebKey) MarshalJSON() ([]byte, error) {
 	raw.Alg = k.Algorithm
 	raw.Use = k.Use
 
-	return json.Marshal(raw)
+	return MarshalJSON(raw)
 }
 
 // UnmarshalJSON reads a key from its JSON representation.

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -27,8 +27,6 @@ import (
 	"math/big"
 	"reflect"
 	"testing"
-
-	"github.com/square/go-jose/json"
 )
 
 func TestCurveSize(t *testing.T) {
@@ -221,7 +219,7 @@ func TestMarshalNonPointer(t *testing.T) {
 	ek := EmbedsKey{
 		Key: parsedKey,
 	}
-	out, err := json.Marshal(ek)
+	out, err := MarshalJSON(ek)
 	if err != nil {
 		t.Error(fmt.Sprintf("Error marshalling JSON: %v", err))
 		return
@@ -432,7 +430,7 @@ func TestMarshalUnmarshalJWKSet(t *testing.T) {
 	set.Keys = append(set.Keys, jwk1)
 	set.Keys = append(set.Keys, jwk2)
 
-	jsonbar, err := json.Marshal(&set)
+	jsonbar, err := MarshalJSON(&set)
 	if err != nil {
 		t.Error("problem marshalling set", err)
 	}
@@ -441,7 +439,7 @@ func TestMarshalUnmarshalJWKSet(t *testing.T) {
 	if err != nil {
 		t.Error("problem unmarshalling set", err)
 	}
-	jsonbar2, err := json.Marshal(&set2)
+	jsonbar2, err := MarshalJSON(&set2)
 	if err != nil {
 		t.Error("problem marshalling set", err)
 	}

--- a/signing_test.go
+++ b/signing_test.go
@@ -24,8 +24,6 @@ import (
 	"fmt"
 	"io"
 	"testing"
-
-	"github.com/square/go-jose/json"
 )
 
 type staticNonceSource string
@@ -350,7 +348,7 @@ func TestSignerKid(t *testing.T) {
 		t.Error("problem unmarshalling base JWK", err)
 	}
 	jsonmsi["kid"] = kid
-	jsonbar2, err := json.Marshal(jsonmsi)
+	jsonbar2, err := MarshalJSON(jsonmsi)
 	if err != nil {
 		t.Error("problem marshalling kided JWK", err)
 	}


### PR DESCRIPTION
@alokmenghrajani @mcpherrinm 
Erroneously left out some of the calls to `json.Marshal` in the previous pull request. 