### PR TITLE
add import annotation and rewrite import path for gopkg.in

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ go:
 - 1.6
 - tip
 
+go_import_path: gopkg.in/square/go-jose.v1
+
 before_script:
 - export PATH=$HOME/.local/bin:$PATH
 

--- a/asymmetric.go
+++ b/asymmetric.go
@@ -28,7 +28,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/square/go-jose/cipher"
+	"gopkg.in/square/go-jose.v1/cipher"
 )
 
 // A generic RSA-based encrypter/verifier

--- a/doc.go
+++ b/doc.go
@@ -23,4 +23,4 @@ standards.  The library supports both the compact and full serialization
 formats, and has optional support for multiple recipients.
 
 */
-package jose
+package jose // import "gopkg.in/square/go-jose.v1"

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 
 	"github.com/codegangsta/cli"
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 )
 
 func main() {

--- a/json_fork.go
+++ b/json_fork.go
@@ -19,7 +19,7 @@
 package jose
 
 import (
-	"github.com/square/go-jose/json"
+	"gopkg.in/square/go-jose.v1/json"
 )
 
 func MarshalJSON(v interface{}) ([]byte, error) {

--- a/symmetric.go
+++ b/symmetric.go
@@ -28,7 +28,7 @@ import (
 	"hash"
 	"io"
 
-	"github.com/square/go-jose/cipher"
+	"gopkg.in/square/go-jose.v1/cipher"
 )
 
 // Random reader (stubbed out in tests)


### PR DESCRIPTION
This commit updates the import paths on the "v1" branch to
reference gopkg.in instead of github.com.

The command used to rewrite the imports was

```
sed -i.bak 's|"github\.com/square/go-jose|"gopkg.in/square/go-jose.v1|' \
    $(find . -name '*.go')
```

Fixes #78