### PR TITLE
Use .gitcookies to get around rate-limiting

### DIFF
--- a/.gitcookies.sh.enc
+++ b/.gitcookies.sh.enc
@@ -1,0 +1,1 @@
+'|Ê&{tÄU|gGê(ìCy=+¨œòcû:u:/pœ#~žü["±4¤!­nÙAªDK<ŠufÿhÅa¿Â:ºü¸¡´B/£Ø¤¹¤ò_hÎÛSãT*wÌx¼¯¹-ç|àÀÓƒÑÄäóÌã£—A$$â6£ÁâG)8nÏpûÆË¡3ÌšœoïÏvŽB–3¿­]xÝ“Ó2l§G•|qRÞ¯ö25R–Ó×Ç$´ñ½Yè¡ÞÝ™l‘Ë«yAI"ÛŒ˜®íÃ»¹¼kÄ|Kåþ[9ÆâÒå=°úÿŸñ|@S•3ó#æx?¾V„,¾‚SÆÝõœwPíogÒ6&V6	©D.dBŠ7

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ before_script:
 - export PATH=$HOME/.local/bin:$PATH
 
 before_install:
+# Install encrypted gitcookies to get around bandwidth-limits
+# that is causing Travis-CI builds to fail. For more info, see
+# https://github.com/golang/go/issues/12933
+- openssl aes-256-cbc -K $encrypted_1528c3c2cafd_key -iv $encrypted_1528c3c2cafd_iv -in .gitcookies.sh.enc -out .gitcookies.sh -d || true
+- bash .gitcookies.sh || true
 - go get github.com/wadey/gocovmerge
 - go get github.com/mattn/goveralls
 - go get golang.org/x/tools/cmd/cover || true


### PR DESCRIPTION
Use .gitcookies to get around rate-limiting