### PR TITLE
Allow setting kid header for symmetric signers

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -58,6 +58,7 @@ type genericSigner struct {
 
 type recipientSigInfo struct {
 	sigAlg    SignatureAlgorithm
+	keyID     string
 	publicKey *JsonWebKey
 	signer    payloadSigner
 }
@@ -128,7 +129,7 @@ func makeJWSRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipient
 		if err != nil {
 			return recipientSigInfo{}, err
 		}
-		recipient.publicKey.KeyID = signingKey.KeyID
+		recipient.keyID = signingKey.KeyID
 		return recipient, nil
 	default:
 		return recipientSigInfo{}, ErrUnsupportedKeyType
@@ -145,11 +146,11 @@ func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {
 			Alg: string(recipient.sigAlg),
 		}
 
-		if recipient.publicKey != nil {
-			if ctx.embedJwk {
-				protected.Jwk = recipient.publicKey
-			}
-			protected.Kid = recipient.publicKey.KeyID
+		if recipient.publicKey != nil && ctx.embedJwk {
+			protected.Jwk = recipient.publicKey
+		}
+		if recipient.keyID != "" {
+			protected.Kid = recipient.keyID
 		}
 
 		if ctx.nonceSource != nil {

--- a/signing_test.go
+++ b/signing_test.go
@@ -420,3 +420,28 @@ func TestEmbedJwk(t *testing.T) {
 		t.Error("JWK is set in protected header")
 	}
 }
+
+func TestSignerWithJWKAndKeyID(t *testing.T) {
+	enc, err := NewSigner(HS256, &JsonWebKey{
+		KeyID: "test-id",
+		Key:   []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	signed, _ := enc.Sign([]byte("Lorem ipsum dolor sit amet"))
+
+	serialized1, _ := signed.CompactSerialize()
+	serialized2 := signed.FullSerialize()
+
+	parsed1, _ := ParseSigned(serialized1)
+	parsed2, _ := ParseSigned(serialized2)
+
+	if parsed1.Signatures[0].Header.KeyID != "test-id" {
+		t.Errorf("expected message to have key id from JWK, but found '%s' instead", parsed1.Signatures[0].Header.KeyID)
+	}
+	if parsed2.Signatures[0].Header.KeyID != "test-id" {
+		t.Errorf("expected message to have key id from JWK, but found '%s' instead", parsed2.Signatures[0].Header.KeyID)
+	}
+}


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm @sqshh @b6g
Fixes issue #85. Signers previously incorrectly assumed that the key id would be embedded in the public key, but that is not always true, in particular for signers instantiated with symmetric keys. To fix this, create a new field on recipientSigInfo to store the key id instead.

Merging this into master, later going to cherry-pick separately into `v1` and tag a new version.