### PR TITLE
Add JsonWebKey.Valid method

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -192,6 +192,34 @@ func (k *JsonWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
+// Valid checks that the key contains the expected parameters
+func (k *JsonWebKey) Valid() bool {
+	if k.Key == nil {
+		return false
+	}
+	switch key := k.Key.(type) {
+	case *ecdsa.PublicKey:
+		if key.Curve == nil || key.X == nil || key.Y == nil {
+			return false
+		}
+	case *ecdsa.PrivateKey:
+		if key.Curve == nil || key.X == nil || key.Y == nil || key.D == nil {
+			return false
+		}
+	case *rsa.PublicKey:
+		if key.N == nil || key.E == 0 {
+			return false
+		}
+	case *rsa.PrivateKey:
+		if key.N == nil || key.E == 0 || key.D == nil || len(key.Primes) < 2 {
+			return false
+		}
+	default:
+		return false
+	}
+	return true
+}
+
 func (key rawJsonWebKey) rsaPublicKey() (*rsa.PublicKey, error) {
 	if key.N == nil || key.E == nil {
 		return nil, fmt.Errorf("square/go-jose: invalid RSA key, missing n/e values")

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -523,3 +523,30 @@ func TestJWKSymmetricInvalid(t *testing.T) {
 		t.Error("excepted error on unmarshaling invalid symmetric JWK object")
 	}
 }
+
+func TestJWKValid(t *testing.T) {
+	bigInt := big.NewInt(0)
+	eccPub := ecdsa.PublicKey{elliptic.P256(), bigInt, bigInt}
+	rsaPub := rsa.PublicKey{bigInt, 1}
+	cases := []struct {
+		key              interface{}
+		expectedValidity bool
+	}{
+		{nil, false},
+		{&ecdsa.PublicKey{}, false},
+		{&eccPub, true},
+		{&ecdsa.PrivateKey{}, false},
+		{&ecdsa.PrivateKey{eccPub, bigInt}, true},
+		{&rsa.PublicKey{}, false},
+		{&rsaPub, true},
+		{&rsa.PrivateKey{}, false},
+		{&rsa.PrivateKey{rsaPub, bigInt, []*big.Int{bigInt, bigInt}, rsa.PrecomputedValues{}}, true},
+	}
+
+	for _, tc := range cases {
+		k := &JsonWebKey{Key: tc.key}
+		if valid := k.Valid(); valid != tc.expectedValidity {
+			t.Errorf("expected Valid to return %t, got %t", tc.expectedValidity, valid)
+		}
+	}
+}


### PR DESCRIPTION
Adds the method `Valid` to `JsonWebKey` to allow testing the validity of the wrapped key. It may make sense to utilize this in the Marshal/Unmarshal methods as well.

Unblocks letsencrypt/boulder#1728.

cc @jsha