### PR TITLE
Allow pointer & non-pointer args as custom claims

### DIFF
--- a/jwt/builder_test.go
+++ b/jwt/builder_test.go
@@ -86,7 +86,7 @@ func TestBuilderHeadersSigner(t *testing.T) {
 		}
 		jws, err := jose.ParseSigned(token)
 		if err != nil {
-			t.Errorf("case %d: parse signed: %v", err)
+			t.Errorf("case %d: parse signed: %v", i, err)
 			continue
 		}
 		gotKeyIDs := make([]string, len(jws.Signatures))
@@ -96,7 +96,7 @@ func TestBuilderHeadersSigner(t *testing.T) {
 		sort.Strings(wantKeyIDs)
 		sort.Strings(gotKeyIDs)
 		if !reflect.DeepEqual(wantKeyIDs, gotKeyIDs) {
-			t.Errorf("case %d: wanted=%q got=%q", wantKeyIDs, gotKeyIDs)
+			t.Errorf("case %d: wanted=%q got=%q", i, wantKeyIDs, gotKeyIDs)
 		}
 	}
 }

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -18,8 +18,6 @@
 package jwt
 
 import (
-	"crypto/rand"
-	"crypto/rsa"
 	"testing"
 	"time"
 
@@ -32,11 +30,7 @@ type testClaims struct {
 }
 
 func TestCustomClaimsNonPointer(t *testing.T) {
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("error generating key: %v", err)
-	}
-	signingKey := jose.SigningKey{Algorithm: jose.RS256, Key: priv}
+	signingKey := jose.SigningKey{Algorithm: jose.RS256, Key: testPrivRSAKey1}
 	signer, err := jose.NewSigner(signingKey, nil)
 	if err != nil {
 		t.Fatalf("error generating token: %v", err)
@@ -51,17 +45,13 @@ func TestCustomClaimsNonPointer(t *testing.T) {
 	}
 
 	out := &testClaims{}
-	if assert.NoError(t, parsed.Claims(out, &priv.PublicKey)) {
+	if assert.NoError(t, parsed.Claims(out, &testPrivRSAKey1.PublicKey)) {
 		assert.Equal(t, out.Subject, "foo")
 	}
 }
 
 func TestCustomClaimsPointer(t *testing.T) {
-	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		t.Fatalf("error generating key: %v", err)
-	}
-	signingKey := jose.SigningKey{Algorithm: jose.RS256, Key: priv}
+	signingKey := jose.SigningKey{Algorithm: jose.RS256, Key: testPrivRSAKey1}
 	signer, err := jose.NewSigner(signingKey, nil)
 	if err != nil {
 		t.Fatalf("error generating token: %v", err)
@@ -76,7 +66,7 @@ func TestCustomClaimsPointer(t *testing.T) {
 	}
 
 	out := &testClaims{}
-	if assert.NoError(t, parsed.Claims(out, &priv.PublicKey)) {
+	if assert.NoError(t, parsed.Claims(out, &testPrivRSAKey1.PublicKey)) {
 		assert.Equal(t, out.Subject, "foo")
 	}
 }

--- a/jwt/json.go
+++ b/jwt/json.go
@@ -99,12 +99,11 @@ func (s *audience) UnmarshalJSON(b []byte) error {
 var claimsType = reflect.TypeOf((*Claims)(nil)).Elem()
 
 func publicClaims(cl interface{}) (*Claims, error) {
-	v := reflect.ValueOf(cl)
-	if v.IsNil() || v.Kind() != reflect.Ptr || v.Elem().Kind() != reflect.Struct {
+	v := reflect.Indirect(reflect.ValueOf(cl))
+	if v.Kind() != reflect.Struct {
 		return nil, ErrInvalidClaims
 	}
 
-	v = v.Elem()
 	f := v.FieldByName("Claims")
 	if !f.IsValid() || f.Type() != claimsType {
 		return nil, nil


### PR DESCRIPTION
r: @ericchiang @shaxbee
Makes changes to allow both pointer & non-pointer args as custom claims, via `reflect.Indirect`. Fixes #100. 