### PR TITLE
Reject invalid embedded public keys

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -217,7 +217,17 @@ func (k *JsonWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
-// Valid checks that the key contains the expected parameters
+// IsPublic returns true if the JWK represents a public key (not symmetric, not private).
+func (k *JsonWebKey) IsPublic() bool {
+	switch k.Key.(type) {
+	case *ecdsa.PublicKey, *rsa.PublicKey:
+		return true
+	default:
+		return false
+	}
+}
+
+// Valid checks that the key contains the expected parameters.
 func (k *JsonWebKey) Valid() bool {
 	if k.Key == nil {
 		return false

--- a/jws.go
+++ b/jws.go
@@ -17,6 +17,7 @@
 package jose
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -126,6 +127,7 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 			}
 		}
 
+		// Check that there is not a nonce in the unprotected header
 		if parsed.Header != nil && parsed.Header.Nonce != "" {
 			return nil, ErrUnprotectedNonce
 		}
@@ -148,6 +150,13 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 		}
 
 		signature.Header = signature.mergedHeaders().sanitized()
+
+		// As per RFC 7515 Section 4.1.3, only public keys are allowed to be embedded.
+		jwk := signature.Header.JsonWebKey
+		if jwk != nil && (!jwk.Valid() || !jwk.IsPublic()) {
+			return nil, errors.New("square/go-jose: invalid embedded jwk, must be public key")
+		}
+
 		obj.Signatures = append(obj.Signatures, signature)
 	}
 
@@ -165,14 +174,20 @@ func (parsed *rawJsonWebSignature) sanitized() (*JsonWebSignature, error) {
 			return nil, ErrUnprotectedNonce
 		}
 
+		obj.Signatures[i].Header = obj.Signatures[i].mergedHeaders().sanitized()
 		obj.Signatures[i].Signature = sig.Signature.bytes()
+
+		// As per RFC 7515 Section 4.1.3, only public keys are allowed to be embedded.
+		jwk := obj.Signatures[i].Header.JsonWebKey
+		if jwk != nil && (!jwk.Valid() || !jwk.IsPublic()) {
+			return nil, errors.New("square/go-jose: invalid embedded jwk, must be public key")
+		}
 
 		// Copy value of sig
 		original := sig
 
 		obj.Signatures[i].header = sig.Header
 		obj.Signatures[i].original = &original
-		obj.Signatures[i].Header = obj.Signatures[i].mergedHeaders().sanitized()
 	}
 
 	return obj, nil

--- a/jws_test.go
+++ b/jws_test.go
@@ -22,6 +22,16 @@ import (
 	"testing"
 )
 
+func TestEmbeddedHMAC(t *testing.T) {
+	// protected: {"alg":"HS256", "jwk":{"kty":"oct", "k":"MTEx"}}, aka HMAC key.
+	msg := `{"payload":"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ","protected":"eyJhbGciOiJIUzI1NiIsICJqd2siOnsia3R5Ijoib2N0IiwgImsiOiJNVEV4In19","signature":"lvo41ZZsuHwQvSh0uJtEXRR3vmuBJ7in6qMoD7p9jyo"}`
+
+	_, err := ParseSigned(msg)
+	if err == nil {
+		t.Error("should not allow parsing JWS with embedded JWK with HMAC key")
+	}
+}
+
 func TestCompactParseJWS(t *testing.T) {
 	// Should parse
 	msg := "eyJhbGciOiJYWVoifQ.cGF5bG9hZA.c2lnbmF0dXJl"


### PR DESCRIPTION
Reject invalid embedded public keys in JWS headers. Per RFC 7515 Section 4.1.3, the embedded JWK in a JWS header should only ever be a public key. Right now we accept anything, even invalid keys. This makes sure the embedded key (1) is valid and (2) is a public key, not a private key (or symmetric key). 