### PR TITLE
Benchmark JWT Encode/Decode

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -104,3 +104,12 @@ func (s *Audience) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
+
+func (s Audience) Contains(v string) bool {
+	for _, a := range s {
+		if a == v {
+			return true
+		}
+	}
+	return false
+}

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -1,14 +1,33 @@
+/*-
+ * Copyright 2016 Zbigniew Mandziejewicz
+ * Copyright 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package jwt_test
 
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 var sharedKey = []byte("secret")
+var sharedEncryptionKey = []byte("itsa16bytesecret")
 var signer, _ = jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: sharedKey}, &jose.SignerOptions{})
 
 func ExampleParseSigned() {
@@ -42,6 +61,51 @@ func ExampleParseEncrypted() {
 	//Output: iss: issuer, sub: subject
 }
 
+func ExampleClaims_Validate() {
+	cl := jwt.Claims{
+		Subject:   "subject",
+		Issuer:    "issuer",
+		NotBefore: jwt.NewNumericDate(time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Expiry:    jwt.NewNumericDate(time.Date(2016, 1, 1, 0, 15, 0, 0, time.UTC)),
+		Audience:  jwt.Audience{"leela", "fry"},
+	}
+
+	err := cl.Validate(jwt.Expected{
+		Issuer: "issuer",
+		Time:   time.Date(2016, 1, 1, 0, 10, 0, 0, time.UTC),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("valid!")
+	// Output: valid!
+}
+
+func ExampleClaims_Validate_withParse() {
+	raw := `eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.gpHyA1B1H6X4a4Edm9wo7D3X2v3aLSDBDG2_5BzXYe0`
+	tok, err := jwt.ParseSigned(raw)
+	if err != nil {
+		panic(err)
+	}
+
+	cl := jwt.Claims{}
+	if err := tok.Claims(sharedKey, &cl); err != nil {
+		panic(err)
+	}
+
+	err = cl.Validate(jwt.Expected{
+		Issuer:  "issuer",
+		Subject: "subject",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("valid!")
+	// Output: valid!
+}
+
 func ExampleSigned() {
 	key := []byte("secret")
 	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, &jose.SignerOptions{})
@@ -50,8 +114,10 @@ func ExampleSigned() {
 	}
 
 	cl := jwt.Claims{
-		Subject: "subject",
-		Issuer:  "issuer",
+		Subject:   "subject",
+		Issuer:    "issuer",
+		NotBefore: jwt.NewNumericDate(time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)),
+		Audience:  jwt.Audience{"leela", "fry"},
 	}
 	raw, err := jwt.Signed(sig).Claims(cl).CompactSerialize()
 	if err != nil {
@@ -59,12 +125,11 @@ func ExampleSigned() {
 	}
 
 	fmt.Println(raw)
-	// Output: eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJzdWJqZWN0In0.gpHyA1B1H6X4a4Edm9wo7D3X2v3aLSDBDG2_5BzXYe0
+	// Output: eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOlsibGVlbGEiLCJmcnkiXSwiaXNzIjoiaXNzdWVyIiwibmJmIjoxLjQ1MTYwNjRlKzA5LCJzdWIiOiJzdWJqZWN0In0.uazfxZNgnlLdNDK7JkuYj3LlT4jSyEDG8EWISBPUuME
 }
 
 func ExampleEncrypted() {
-	key := []byte("itsa16bytesecret")
-	enc, err := jose.NewEncrypter(jose.A128GCM, jose.Recipient{Algorithm: jose.DIRECT, Key: key}, nil)
+	enc, err := jose.NewEncrypter(jose.A128GCM, jose.Recipient{Algorithm: jose.DIRECT, Key: sharedEncryptionKey}, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -24,12 +24,12 @@ import (
 )
 
 var (
-	sharedKey                    = []byte("secret")
-	sharedEncryptionKey          = []byte("itsa16bytesecret")
-	signedToken                  = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWJqZWN0IiwiaXNzIjoiaXNzdWVyIiwic2NvcGVzIjpbInMxIiwiczIiXX0.Y6_PfQHrzRJ_Vlxij5VI07-pgDIuJNN3Z_g5sSaGQ0c`
+	hmacSignedToken              = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWJqZWN0IiwiaXNzIjoiaXNzdWVyIiwic2NvcGVzIjpbInMxIiwiczIiXX0.Y6_PfQHrzRJ_Vlxij5VI07-pgDIuJNN3Z_g5sSaGQ0c`
+	rsaSignedToken               = `eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzY29wZXMiOlsiczEiLCJzMiJdLCJzdWIiOiJzdWJqZWN0In0.UDDtyK9gC9kyHltcP7E_XODsnqcJWZIiXeGmSAH7SE9YKy3N0KSfFIN85dCNjTfs6zvy4rkrCHzLB7uKAtzMearh3q7jL4nxbhUMhlUcs_9QDVoN4q_j58XmRqBqRnBk-RmDu9TgcV8RbErP4awpIhwWb5UU-hR__4_iNbHdKqwSUPDKYGlf5eicuiYrPxH8mxivk4LRD-vyRdBZZKBt0XIDnEU4TdcNCzAXojkftqcFWYsczwS8R4JHd1qYsMyiaWl4trdHZkO4QkeLe34z4ZAaPMt3wE-gcU-VoqYTGxz-K3Le2VaZ0r3j_z6bOInsv0yngC_cD1dCXMyQJWnWjQ`
 	invalidPayloadSignedToken    = `eyJhbGciOiJIUzI1NiJ9.aW52YWxpZC1wYXlsb2Fk.ScBKKm18jcaMLGYDNRUqB5gVMRZl4DM6dh3ShcxeNgY`
 	invalidPartsSignedToken      = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzdWJqZWN0IiwiaXNzIjoiaXNzdWVyIiwic2NvcGVzIjpbInMxIiwiczIiXX0`
-	encryptedToken               = `eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..NZrU98U4QNO0y-u6.HSq5CvlmkUT1BPqLGZ4.1-zuiZ4RbHrTTUoA8Dvfhg`
+	hmacEncryptedToken           = `eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..NZrU98U4QNO0y-u6.HSq5CvlmkUT1BPqLGZ4.1-zuiZ4RbHrTTUoA8Dvfhg`
+	rsaEncryptedToken            = `eyJhbGciOiJSU0ExXzUiLCJlbmMiOiJBMTI4Q0JDLUhTMjU2In0.IvkVHHiI8JwwavvTR80xGjYvkzubMrZ-TDDx8k8SNJMEylfFfNUc7F2rC3WAABF_xmJ3SW2A6on-S6EAG97k0RsjqHHNqZuaFpDvjeuLqZFfYKzI45aCtkGG4C2ij2GbeySqJ784CcvFJPUWJ-6VPN2Ho2nhefUSqig0jE2IvOKy1ywTj_VBVBxF_dyXFnXwxPKGUQr3apxrWeRJfDh2Cf8YPBlLiRznjfBfwgePB1jP7WCZNwItj10L7hsT_YWEx01XJcbxHaXFLwKyVzwWaDhreFyaWMRbGqEfqVuOT34zfmhLDhQlgLLwkXrvYqX90NsQ9Ftg0LLIfRMbsfdgug.BFy2Tj1RZN8yq2Lk-kMiZQ.9Z0eOyPiv5cEzmXh64RlAQ36Uvz0WpZgqRcc2_69zHTmUOv0Vnl1I6ks8sTraUEvukAilolNBjBj47s0b4b-Og.VM8-eJg5ZsqnTqs0LtGX_Q`
 	invalidPayloadEncryptedToken = `eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..T4jCS4Yyw1GCH0aW.y4gFaMITdBs_QZM8RKrL.6MPyk1cMVaOJFoNGlEuaRQ`
 	invalidPartsEncryptedToken   = `eyJhbGciOiJkaXIiLCJlbmMiOiJBMTI4R0NNIn0..NZrU98U4QNO0y-u6.HSq5CvlmkUT1BPqLGZ4`
 )
@@ -39,7 +39,7 @@ type customClaims struct {
 }
 
 func TestDecodeToken(t *testing.T) {
-	tok, err := ParseSigned(signedToken)
+	tok, err := ParseSigned(hmacSignedToken)
 	if assert.NoError(t, err, "Error parsing signed token.") {
 		c := &Claims{}
 		c2 := &customClaims{}
@@ -49,32 +49,68 @@ func TestDecodeToken(t *testing.T) {
 			assert.Equal(t, []string{"s1", "s2"}, c2.Scopes)
 		}
 	}
-
 	assert.EqualError(t, tok.Claims([]byte("invalid-secret")), "square/go-jose: error in cryptographic primitive")
 
-	tok2, err := ParseSigned(invalidPayloadSignedToken)
+	tok2, err := ParseSigned(rsaSignedToken)
+	if assert.NoError(t, err, "Error parsing encrypted token.") {
+		c := make(map[string]interface{})
+		if assert.NoError(t, tok2.Claims(&testPrivRSAKey1.PublicKey, &c)) {
+			assert.Equal(t, map[string]interface{}{
+				"sub":    "subject",
+				"iss":    "issuer",
+				"scopes": []interface{}{"s1", "s2"},
+			}, c)
+		}
+	}
+	assert.EqualError(t, tok.Claims(&testPrivRSAKey2.PublicKey), "square/go-jose: error in cryptographic primitive")
+
+	tok3, err := ParseSigned(invalidPayloadSignedToken)
 	if assert.NoError(t, err, "Error parsing signed token.") {
-		assert.Error(t, tok2.Claims(sharedKey, &Claims{}), "Expected unmarshaling claims to fail.")
+		assert.Error(t, tok3.Claims(sharedKey, &Claims{}), "Expected unmarshaling claims to fail.")
 	}
 
 	_, err = ParseSigned(invalidPartsSignedToken)
 	assert.EqualError(t, err, "square/go-jose: compact JWS format must have three parts")
 
-	tok3, err := ParseEncrypted(encryptedToken)
+	tok4, err := ParseEncrypted(hmacEncryptedToken)
 	if assert.NoError(t, err, "Error parsing encrypted token.") {
-		c := &Claims{}
-		if assert.NoError(t, tok3.Claims(sharedEncryptionKey, c)) {
+		c := Claims{}
+		if assert.NoError(t, tok4.Claims(sharedEncryptionKey, &c)) {
 			assert.Equal(t, "foo", c.Subject)
 		}
 	}
+	assert.EqualError(t, tok4.Claims([]byte("invalid-secret-key")), "square/go-jose: error in cryptographic primitive")
 
-	assert.EqualError(t, tok3.Claims([]byte("invalid-secret-key")), "square/go-jose: error in cryptographic primitive")
-
-	tok4, err := ParseEncrypted(invalidPayloadEncryptedToken)
+	tok5, err := ParseEncrypted(rsaEncryptedToken)
 	if assert.NoError(t, err, "Error parsing encrypted token.") {
-		assert.Error(t, tok4.Claims(sharedEncryptionKey, &Claims{}))
+		c := make(map[string]interface{})
+		if assert.NoError(t, tok5.Claims(testPrivRSAKey1, &c)) {
+			assert.Equal(t, map[string]interface{}{
+				"sub":    "subject",
+				"iss":    "issuer",
+				"scopes": []interface{}{"s1", "s2"},
+			}, c)
+		}
+	}
+	assert.EqualError(t, tok5.Claims(testPrivRSAKey2), "square/go-jose: error in cryptographic primitive")
+
+	tok6, err := ParseEncrypted(invalidPayloadEncryptedToken)
+	if assert.NoError(t, err, "Error parsing encrypted token.") {
+		assert.Error(t, tok6.Claims(sharedEncryptionKey, &Claims{}))
 	}
 
 	_, err = ParseEncrypted(invalidPartsEncryptedToken)
 	assert.EqualError(t, err, "square/go-jose: compact JWE format must have five parts")
+}
+
+func BenchmarkDecodeSignedToken(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ParseSigned(hmacSignedToken)
+	}
+}
+
+func BenchmarkDecodeEncryptedHMACToken(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		ParseEncrypted(hmacEncryptedToken)
+	}
 }

--- a/jwt/validation.go
+++ b/jwt/validation.go
@@ -24,13 +24,19 @@ const (
 	DefaultLeeway = 1.0 * time.Minute
 )
 
-// Expected defines values used for claims validation.
+// Expected defines values used for protected claims validation.
+// If field has zero value then validation is skipped.
 type Expected struct {
-	Issuer   string
-	Subject  string
-	Audience []string
-	ID       string
-	Time     time.Time
+	// Issuer matches the "iss" claim exactly.
+	Issuer string
+	// Subject matches the "sub" claim exactly.
+	Subject string
+	// Audience matches the values in "aud" claim, regardless of their order.
+	Audience Audience
+	// ID matches the "jti" claim exactly.
+	ID string
+	// Time matches the "exp" and "ebf" claims with leeway.
+	Time time.Time
 }
 
 // WithTime copies expectations with new time.
@@ -68,8 +74,8 @@ func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
 			return ErrInvalidAudience
 		}
 
-		for i, a := range e.Audience {
-			if a != c.Audience[i] {
+		for _, v := range e.Audience {
+			if !c.Audience.Contains(v) {
 				return ErrInvalidAudience
 			}
 		}

--- a/jwt/validation_test.go
+++ b/jwt/validation_test.go
@@ -36,6 +36,7 @@ func TestFieldsMatch(t *testing.T) {
 		{Issuer: "issuer"},
 		{Subject: "subject"},
 		{Audience: Audience{"a1", "a2"}},
+		{Audience: Audience{"a2", "a1"}},
 		{ID: "42"},
 	}
 
@@ -49,6 +50,7 @@ func TestFieldsMatch(t *testing.T) {
 	}{
 		{Expected{Issuer: "invalid-issuer"}, ErrInvalidIssuer},
 		{Expected{Subject: "invalid-subject"}, ErrInvalidSubject},
+		{Expected{Audience: Audience{"a1"}}, ErrInvalidAudience},
 		{Expected{Audience: Audience{"a1", "invalid-audience"}}, ErrInvalidAudience},
 		{Expected{Audience: Audience{"invalid-audience"}}, ErrInvalidAudience},
 		{Expected{ID: "invalid-id"}, ErrInvalidID},


### PR DESCRIPTION
Sorry for spamming with PRs.

* Added benchmarks for Builder and JSONWebToken - seems like claims marshal/unmarshal roundtrip is not a bottleneck.
* Added examples of validation
* Added tests for parsing RSA signed/encoded tokens
* Added missing copyright header in jwt/examples_test.go
* Added Audience.Contains method
* Audience claim ("aud") is compared ignoring the order of values