### PR TITLE
Update README to links to go-jose.v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # Go JOSE 
 
-[![godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/gopkg.in/square/go-jose.v1) [![license](http://img.shields.io/badge/license-apache_2.0-blue.svg?style=flat)](https://raw.githubusercontent.com/square/go-jose/master/LICENSE)
-[![release](https://img.shields.io/github/release/square/go-jose.svg?style=flat)](https://github.com/square/go-jose/releases)
+[![godoc](http://img.shields.io/badge/godoc-version_1-blue.svg?style=flat)](https://godoc.org/gopkg.in/square/go-jose.v1)
+[![godoc](http://img.shields.io/badge/godoc-version_2-blue.svg?style=flat)](https://godoc.org/gopkg.in/square/go-jose.v2)
+[![license](http://img.shields.io/badge/license-apache_2.0-blue.svg?style=flat)](https://raw.githubusercontent.com/square/go-jose/master/LICENSE)
 [![build](https://travis-ci.org/square/go-jose.svg?branch=master)](https://travis-ci.org/square/go-jose)
 [![coverage](https://coveralls.io/repos/github/square/go-jose/badge.svg?branch=master)](https://coveralls.io/r/square/go-jose)
 
 Package jose aims to provide an implementation of the Javascript Object Signing
-and Encryption set of standards. For the moment, it mainly focuses on encryption
-and signing based on the JSON Web Encryption and JSON Web Signature standards.
+and Encryption set of standards. This includes support for JSON Web Encryption,
+JSON Web Signature, and JSON Web Token standards.
 
 **Disclaimer**: This library contains encryption software that is subject to
 the U.S. Export Administration Regulations. You may not export, re-export,
@@ -20,44 +21,50 @@ US maintained blocked list.
 ## Overview
 
 The implementation follows the
-[JSON Web Encryption](http://dx.doi.org/10.17487/RFC7516)
-standard (RFC 7516) and
-[JSON Web Signature](http://dx.doi.org/10.17487/RFC7515)
-standard (RFC 7515). Tables of supported algorithms are shown below.
-The library supports both the compact and full serialization formats, and has
-optional support for multiple recipients. It also comes with a small
-command-line utility
-([`jose-util`](https://github.com/square/go-jose/tree/master/jose-util))
+[JSON Web Encryption](http://dx.doi.org/10.17487/RFC7516) (RFC 7516),
+[JSON Web Signature](http://dx.doi.org/10.17487/RFC7515) (RFC 7515), and
+[JSON Web Token](http://dx.doi.org/10.17487/RFC7519) (RFC 7519).
+Tables of supported algorithms are shown below. The library supports both
+the compact and full serialization formats, and has optional support for
+multiple recipients. It also comes with a small command-line utility
+([`jose-util`](https://github.com/square/go-jose/tree/v2/jose-util))
 for dealing with JOSE messages in a shell.
 
 **Note**: We use a forked version of the `encoding/json` package from the Go
 standard library which uses case-sensitive matching for member names (instead
 of [case-insensitive matching](https://www.ietf.org/mail-archive/web/json/current/msg03763.html)).
 This is to avoid differences in interpretation of messages between go-jose and
-libraries in other languages. If you do not like this behavior, you can use the
-`std_json` build tag to disable it (though we do not recommend doing so).
+libraries in other languages.
 
 ### Versions
 
 We use [gopkg.in](https://gopkg.in) for versioning.
 
-[Version 1](https://gopkg.in/square/go-jose.v1) is the current stable version:
+[Version 1](https://gopkg.in/square/go-jose.v1) is the old stable version:
 
     import "gopkg.in/square/go-jose.v1"
 
+[Version 2](https://gopkg.in/square/go-jose.v2) is for new development:
+
+    import "gopkg.in/square/go-jose.v2"
+
 The interface for [go-jose.v1](https://gopkg.in/square/go-jose.v1) will remain
-backwards compatible. We're currently sketching out ideas for a new version, to
-clean up the interface a bit. If you have ideas or feature requests [please let
-us know](https://github.com/square/go-jose/issues/64)!
+backwards compatible. No new feature development will take place on the `v1` branch,
+however bug fixes and security fixes will be backported.
+
+The interface for [go-jose.v2](https://gopkg.in/square/go-jose.v2) is mostly 
+stable, but we suggest pinning to a particular revision for now as we still reserve
+the right to make changes. New feature development happens on this branch.
+
+New in [go-jose.v2](https://gopkg.in/square/go-jose.v2) is a
+[jwt](https://godoc.org/gopkg.in/square/go-jose.v2/jwt) sub-package
+contributed by [@shaxbee](https://github.com/shaxbee).
 
 ### Supported algorithms
 
 See below for a table of supported algorithms. Algorithm identifiers match
-the names in the
-[JSON Web Algorithms](http://dx.doi.org/10.17487/RFC7518)
-standard where possible. The
-[Godoc reference](https://godoc.org/github.com/square/go-jose#pkg-constants)
-has a list of constants.
+the names in the [JSON Web Algorithms](http://dx.doi.org/10.17487/RFC7518)
+standard where possible. The Godoc reference has a list of constants.
 
  Key encryption             | Algorithm identifier(s)
  :------------------------- | :------------------------------
@@ -91,122 +98,22 @@ has a list of constants.
 
 See below for a table of supported key types. These are understood by the
 library, and can be passed to corresponding functions such as `NewEncrypter` or
-`NewSigner`. Note that if you are creating a new encrypter or signer with a
-JsonWebKey, the key id of the JsonWebKey (if present) will be added to any
-resulting messages.
+`NewSigner`. Each of these keys can also be wrapped in a JWK if desired, which
+allows attaching a key id.
 
  Algorithm(s)               | Corresponding types
  :------------------------- | -------------------------------
- RSA                        | *[rsa.PublicKey](http://golang.org/pkg/crypto/rsa/#PublicKey), *[rsa.PrivateKey](http://golang.org/pkg/crypto/rsa/#PrivateKey), *[jose.JsonWebKey](https://godoc.org/github.com/square/go-jose#JsonWebKey)
- ECDH, ECDSA                | *[ecdsa.PublicKey](http://golang.org/pkg/crypto/ecdsa/#PublicKey), *[ecdsa.PrivateKey](http://golang.org/pkg/crypto/ecdsa/#PrivateKey), *[jose.JsonWebKey](https://godoc.org/github.com/square/go-jose#JsonWebKey)
- AES, HMAC                  | []byte, *[jose.JsonWebKey](https://godoc.org/github.com/square/go-jose#JsonWebKey)
+ RSA                        | *[rsa.PublicKey](http://golang.org/pkg/crypto/rsa/#PublicKey), *[rsa.PrivateKey](http://golang.org/pkg/crypto/rsa/#PrivateKey)
+ ECDH, ECDSA                | *[ecdsa.PublicKey](http://golang.org/pkg/crypto/ecdsa/#PublicKey), *[ecdsa.PrivateKey](http://golang.org/pkg/crypto/ecdsa/#PrivateKey)
+ AES, HMAC                  | []byte
 
 ## Examples
 
-Encryption/decryption example using RSA:
+[![godoc](http://img.shields.io/badge/godoc-version_1-blue.svg?style=flat)](https://godoc.org/gopkg.in/square/go-jose.v1)
+[![godoc](http://img.shields.io/badge/godoc-version_2-blue.svg?style=flat)](https://godoc.org/gopkg.in/square/go-jose.v2)
 
-```Go
-// Generate a public/private key pair to use for this example. The library
-// also provides two utility functions (LoadPublicKey and LoadPrivateKey)
-// that can be used to load keys from PEM/DER-encoded data.
-privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-if err != nil {
-	panic(err)
-}
-
-// Instantiate an encrypter using RSA-OAEP with AES128-GCM. An error would
-// indicate that the selected algorithm(s) are not currently supported.
-publicKey := &privateKey.PublicKey
-encrypter, err := NewEncrypter(RSA_OAEP, A128GCM, publicKey)
-if err != nil {
-	panic(err)
-}
-
-// Encrypt a sample plaintext. Calling the encrypter returns an encrypted
-// JWE object, which can then be serialized for output afterwards. An error
-// would indicate a problem in an underlying cryptographic primitive.
-var plaintext = []byte("Lorem ipsum dolor sit amet")
-object, err := encrypter.Encrypt(plaintext)
-if err != nil {
-	panic(err)
-}
-
-// Serialize the encrypted object using the full serialization format.
-// Alternatively you can also use the compact format here by calling
-// object.CompactSerialize() instead.
-serialized := object.FullSerialize()
-
-// Parse the serialized, encrypted JWE object. An error would indicate that
-// the given input did not represent a valid message.
-object, err = ParseEncrypted(serialized)
-if err != nil {
-	panic(err)
-}
-
-// Now we can decrypt and get back our original plaintext. An error here
-// would indicate the the message failed to decrypt, e.g. because the auth
-// tag was broken or the message was tampered with.
-decrypted, err := object.Decrypt(privateKey)
-if err != nil {
-	panic(err)
-}
-
-fmt.Printf(string(decrypted))
-// output: Lorem ipsum dolor sit amet
-```
-
-Signing/verification example using RSA:
-
-```Go
-// Generate a public/private key pair to use for this example. The library
-// also provides two utility functions (LoadPublicKey and LoadPrivateKey)
-// that can be used to load keys from PEM/DER-encoded data.
-privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-if err != nil {
-	panic(err)
-}
-
-// Instantiate a signer using RSASSA-PSS (SHA512) with the given private key.
-signer, err := NewSigner(PS512, privateKey)
-if err != nil {
-	panic(err)
-}
-
-// Sign a sample payload. Calling the signer returns a protected JWS object,
-// which can then be serialized for output afterwards. An error would
-// indicate a problem in an underlying cryptographic primitive.
-var payload = []byte("Lorem ipsum dolor sit amet")
-object, err := signer.Sign(payload)
-if err != nil {
-	panic(err)
-}
-
-// Serialize the encrypted object using the full serialization format.
-// Alternatively you can also use the compact format here by calling
-// object.CompactSerialize() instead.
-serialized := object.FullSerialize()
-
-// Parse the serialized, protected JWS object. An error would indicate that
-// the given input did not represent a valid message.
-object, err = ParseSigned(serialized)
-if err != nil {
-	panic(err)
-}
-
-// Now we can verify the signature on the payload. An error here would
-// indicate the the message failed to verify, e.g. because the signature was
-// broken or the message was tampered with.
-output, err := object.Verify(&privateKey.PublicKey)
-if err != nil {
-	panic(err)
-}
-
-fmt.Printf(string(output))
-// output: Lorem ipsum dolor sit amet
-```
-
-More examples can be found in the [Godoc
-reference](https://godoc.org/github.com/square/go-jose) for this package. The
-[`jose-util`](https://github.com/square/go-jose/tree/master/jose-util)
-subdirectory also contains a small command-line utility which might
-be useful as an example.
+Examples can be found in the Godoc
+reference for this package. The
+[`jose-util`](https://github.com/square/go-jose/tree/v2/jose-util)
+subdirectory also contains a small command-line utility which might be useful
+as an example.


### PR DESCRIPTION
@shaxbee @mcpherrinm @alokmenghrajani @worldwise001 

Updates README to "publish" version 2. Already importable via gopkg.in. Going to add an official v2.0.0 tag later. I removed the examples because they differ between v1/v2, just links to documentation now instead.