### PR TITLE
Fix base64url decoding

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"math/big"
 	"regexp"
+	"strings"
 )
 
 var stripWhitespaceRegex = regexp.MustCompile("\\s")
@@ -147,7 +148,8 @@ func (b *byteBuffer) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	decoded, err := base64.RawURLEncoding.DecodeString(encoded)
+	// Remove padding if there is any
+	decoded, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(encoded, "="))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Addresses the issue raised in #130.

JSON unmarshalling fails with Base64URL type (URLEncoding with padding). I added an attempt to do `URLEncoding` when `RawURLEncoding` fails.