### PR TITLE
Add support for custom protected headers

### DIFF
--- a/asymmetric_test.go
+++ b/asymmetric_test.go
@@ -242,9 +242,8 @@ func TestInvalidECDecrypt(t *testing.T) {
 	generator := randomKeyGenerator{size: 16}
 
 	// Missing epk header
-	headers := rawHeader{
-		Alg: string(ECDH_ES),
-	}
+	headers := rawHeader{}
+	headers.set(headerAlgorithm, ECDH_ES)
 
 	_, err := dec.decryptKey(headers, nil, generator)
 	if err == nil {
@@ -252,7 +251,7 @@ func TestInvalidECDecrypt(t *testing.T) {
 	}
 
 	// Invalid epk header
-	headers.Epk = &JSONWebKey{}
+	headers.set(headerEPK, &JSONWebKey{})
 
 	_, err = dec.decryptKey(headers, nil, generator)
 	if err == nil {
@@ -443,12 +442,11 @@ func estInvalidECPublicKey(t *testing.T) {
 		D: fromBase64Int("0_NxaRPUMQoAJt50Gz8YiTr8gRTwyEaCumd-MToTmIo"),
 	}
 
-	headers := rawHeader{
-		Alg: string(ECDH_ES),
-		Epk: &JSONWebKey{
-			Key: &invalid.PublicKey,
-		},
-	}
+	headers := rawHeader{}
+	headers.set(headerAlgorithm, ECDH_ES)
+	headers.set(headerEPK, &JSONWebKey{
+		Key: &invalid.PublicKey,
+	})
 
 	dec := ecDecrypterSigner{
 		privateKey: ecTestKey256,

--- a/jwe.go
+++ b/jwe.go
@@ -129,9 +129,15 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
 	}
 
 	// Check that there is not a nonce in the unprotected headers
-	if (parsed.Unprotected != nil && parsed.Unprotected.Nonce != "") ||
-		(parsed.Header != nil && parsed.Header.Nonce != "") {
-		return nil, ErrUnprotectedNonce
+	if parsed.Unprotected != nil {
+		if nonce := parsed.Unprotected.getNonce(); nonce != "" {
+			return nil, ErrUnprotectedNonce
+		}
+	}
+	if parsed.Header != nil {
+		if nonce := parsed.Header.getNonce(); nonce != "" {
+			return nil, ErrUnprotectedNonce
+		}
 	}
 
 	if parsed.Protected != nil && len(parsed.Protected.bytes()) > 0 {
@@ -143,7 +149,12 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
 
 	// Note: this must be called _after_ we parse the protected header,
 	// otherwise fields from the protected header will not get picked up.
-	obj.Header = obj.mergedHeaders(nil).sanitized()
+	var err error
+	mergedHeaders := obj.mergedHeaders(nil)
+	obj.Header, err = mergedHeaders.sanitized()
+	if err != nil {
+		return nil, fmt.Errorf("square/go-jose: cannot sanitize merged headers: %v (%v)", err, mergedHeaders)
+	}
 
 	if len(parsed.Recipients) == 0 {
 		obj.recipients = []recipientInfo{
@@ -161,7 +172,7 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
 			}
 
 			// Check that there is not a nonce in the unprotected header
-			if parsed.Recipients[r].Header != nil && parsed.Recipients[r].Header.Nonce != "" {
+			if parsed.Recipients[r].Header != nil && parsed.Recipients[r].Header.getNonce() != "" {
 				return nil, ErrUnprotectedNonce
 			}
 
@@ -172,7 +183,7 @@ func (parsed *rawJSONWebEncryption) sanitized() (*JSONWebEncryption, error) {
 
 	for _, recipient := range obj.recipients {
 		headers := obj.mergedHeaders(&recipient)
-		if headers.Alg == "" || headers.Enc == "" {
+		if headers.getAlgorithm() == "" || headers.getEncryption() == "" {
 			return nil, fmt.Errorf("square/go-jose: message is missing alg/enc headers")
 		}
 	}

--- a/jws.go
+++ b/jws.go
@@ -132,7 +132,7 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
 		}
 
 		// Check that there is not a nonce in the unprotected header
-		if parsed.Header != nil && parsed.Header.Nonce != "" {
+		if parsed.Header != nil && parsed.Header.getNonce() != "" {
 			return nil, ErrUnprotectedNonce
 		}
 
@@ -153,7 +153,11 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
 			Signature: parsed.Signature,
 		}
 
-		signature.Header = signature.mergedHeaders().sanitized()
+		var err error
+		signature.Header, err = signature.mergedHeaders().sanitized()
+		if err != nil {
+			return nil, err
+		}
 
 		// As per RFC 7515 Section 4.1.3, only public keys are allowed to be embedded.
 		jwk := signature.Header.JSONWebKey
@@ -174,11 +178,16 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
 		}
 
 		// Check that there is not a nonce in the unprotected header
-		if sig.Header != nil && sig.Header.Nonce != "" {
+		if sig.Header != nil && sig.Header.getNonce() != "" {
 			return nil, ErrUnprotectedNonce
 		}
 
-		obj.Signatures[i].Header = obj.Signatures[i].mergedHeaders().sanitized()
+		var err error
+		obj.Signatures[i].Header, err = obj.Signatures[i].mergedHeaders().sanitized()
+		if err != nil {
+			return nil, err
+		}
+
 		obj.Signatures[i].Signature = sig.Signature.bytes()
 
 		// As per RFC 7515 Section 4.1.3, only public keys are allowed to be embedded.

--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -92,7 +92,7 @@ func Encrypted(enc jose.Encrypter) Builder {
 // SignedAndEncrypted creates builder for signed-then-encrypted tokens.
 // ErrInvalidContentType will be returned if encrypter doesn't have JWT content type.
 func SignedAndEncrypted(sig jose.Signer, enc jose.Encrypter) NestedBuilder {
-	if enc.Options().ContentType != "JWT" {
+	if contentType, _ := enc.Options().ExtraHeaders[jose.HeaderContentType].(jose.ContentType); contentType != "JWT" {
 		return &nestedBuilder{
 			builder: builder{
 				err: ErrInvalidContentType,

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -132,7 +132,7 @@ func ExampleClaims_Validate_withParse() {
 
 func ExampleSigned() {
 	key := []byte("secret")
-	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, &jose.SignerOptions{Type: "JWT"})
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, (&jose.SignerOptions{}).WithType("JWT"))
 	if err != nil {
 		panic(err)
 	}
@@ -156,7 +156,7 @@ func ExampleEncrypted() {
 	enc, err := jose.NewEncrypter(
 		jose.A128GCM,
 		jose.Recipient{Algorithm: jose.DIRECT, Key: sharedEncryptionKey},
-		&jose.EncrypterOptions{Type: "JWT"},
+		(&jose.EncrypterOptions{}).WithType("JWT"),
 	)
 	if err != nil {
 		panic(err)
@@ -181,10 +181,7 @@ func ExampleSignedAndEncrypted() {
 			Algorithm: jose.DIRECT,
 			Key:       sharedEncryptionKey,
 		},
-		&jose.EncrypterOptions{
-			Type:        "JWT",
-			ContentType: "JWT",
-		})
+		(&jose.EncrypterOptions{}).WithType("JWT").WithContentType("JWT"))
 	if err != nil {
 		panic(err)
 	}

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -101,7 +101,8 @@ func ParseSignedAndEncrypted(s string) (*NestedJSONWebToken, error) {
 		return nil, err
 	}
 
-	if strings.ToUpper(enc.Header.ContentType) != "JWT" {
+	contentType, _ := enc.Header.ExtraHeaders[jose.HeaderContentType].(string)
+	if strings.ToUpper(contentType) != "JWT" {
 		return nil, ErrInvalidContentType
 	}
 

--- a/symmetric.go
+++ b/symmetric.go
@@ -25,6 +25,7 @@ import (
 	"crypto/sha512"
 	"crypto/subtle"
 	"errors"
+	"fmt"
 	"hash"
 	"io"
 
@@ -229,11 +230,12 @@ func (ctx *symmetricKeyCipher) encryptKey(cek []byte, alg KeyAlgorithm) (recipie
 			return recipientInfo{}, err
 		}
 
+		header := &rawHeader{}
+		header.set(headerIV, newBuffer(parts.iv))
+		header.set(headerTag, newBuffer(parts.tag))
+
 		return recipientInfo{
-			header: &rawHeader{
-				Iv:  newBuffer(parts.iv),
-				Tag: newBuffer(parts.tag),
-			},
+			header:       header,
 			encryptedKey: parts.ciphertext,
 		}, nil
 	case A128KW, A192KW, A256KW:
@@ -258,7 +260,7 @@ func (ctx *symmetricKeyCipher) encryptKey(cek []byte, alg KeyAlgorithm) (recipie
 
 // Decrypt the content encryption key.
 func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipientInfo, generator keyGenerator) ([]byte, error) {
-	switch KeyAlgorithm(headers.Alg) {
+	switch headers.getAlgorithm() {
 	case DIRECT:
 		cek := make([]byte, len(ctx.key))
 		copy(cek, ctx.key)
@@ -266,10 +268,19 @@ func (ctx *symmetricKeyCipher) decryptKey(headers rawHeader, recipient *recipien
 	case A128GCMKW, A192GCMKW, A256GCMKW:
 		aead := newAESGCM(len(ctx.key))
 
+		iv, err := headers.getIV()
+		if err != nil {
+			return nil, fmt.Errorf("square/go-jose: invalid IV: %v", err)
+		}
+		tag, err := headers.getTag()
+		if err != nil {
+			return nil, fmt.Errorf("square/go-jose: invalid tag: %v", err)
+		}
+
 		parts := &aeadParts{
-			iv:         headers.Iv.bytes(),
+			iv:         iv.bytes(),
 			ciphertext: recipient.encryptedKey,
-			tag:        headers.Tag.bytes(),
+			tag:        tag.bytes(),
 		}
 
 		cek, err := aead.decrypt(ctx.key, []byte{}, parts)


### PR DESCRIPTION
Fixes #56.

This ended up a more substantial change in terms of the innards of the library than I was expecting, but here we are.

Of note:

  - Go's JSON library (which go-jose uses a modified version of)
    can either unmarshal into a struct, or into a map, but not both.
    Unmarshalling into a struct allows the unmarshalling to be performed
    according to the struct field's types. Unmarshalling into a map
    results in a generic map-based representation of JSON constructs.

    go-jose used an internal struct to unmarshal the protected header,
    which fixed it to using a finite set of protected headers. Since
    this is incompatible with allowing arbitrary custom headers, it was
    changed for a map. json.RawMessage is used to defer parsing of the
    values of this map so that they can be properly unmarshalled into
    their proper types, rather than generic maps.

    As such, this commit creates a fairly substantial change to the
    library.

  - Because of this, the processing of many fields is necessarily
    deferred to a later stage, meaning the opportunity for errors now
    occurs at a slightly later stage. A few internal methods which were
    previously guaranteed now have errors; call sites have been adjusted
    accordingly.

  - Because the Type and ContentType fields previously
    supported by go-jose v2 are simply specific headers, there's no need
    for them when a general facility is available. Thus, these fields have
    been removed. Convenience methods are available to specify them in
    Options structs. Because v2 is not yet stabilized, we can get away
    with making breaking changes. (Moreover Type/ContentType had not
    yet shown up in a v2.x.x tag, meaning that it doesn't show up on
    godoc.org, nor is it available to people who simply go get
    gopkg.in/square/go-jose.v2, so reliance is unlikely.)