### PR TITLE
Fix crash when using symmetric JSONWebKey for JWS signing

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -177,7 +177,13 @@ func newJWKSigner(alg SignatureAlgorithm, signingKey JSONWebKey) (recipientSigIn
 	if err != nil {
 		return recipientSigInfo{}, err
 	}
-	recipient.publicKey.KeyID = signingKey.KeyID
+	if signingKey.IsPublic() {
+		recipient.publicKey.KeyID = signingKey.KeyID
+	} else {
+		recipient.publicKey = &JSONWebKey{
+			KeyID: signingKey.KeyID,
+		}
+	}
 	return recipient, nil
 }
 

--- a/signing_test.go
+++ b/signing_test.go
@@ -217,11 +217,19 @@ func TestMultiRecipientJWS(t *testing.T) {
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 		0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
 	}
+	jwkSharedKey := JSONWebKey{
+		KeyID: "123",
+		Key:   sharedKey,
+	}
 
 	signer, err := NewMultiSigner([]SigningKey{
 		{RS256, rsaTestKey},
 		{HS384, sharedKey},
+		{HS512, jwkSharedKey},
 	}, nil)
+	if err != nil {
+		t.Fatal("error creating signer: ", err)
+	}
 
 	input := []byte("Lorem ipsum dolor sit amet")
 	obj, err := signer.Sign(input)


### PR DESCRIPTION
When using a symmetric `JSONWebKey` to sign, there is a crash when assigning the `KeyID` as the `recipient.publicKey` is not yet created at:

https://github.com/square/go-jose/blob/v2/signing.go#L180

This just checks `IsPublic()` and if false, creates the structure with the `KeyID`. 

Example (crashes without patch with nil pointer dereference):
```
package main

import (
	"encoding/base64"
	"encoding/json"
	"fmt"
	"os"
	"strings"

	"gopkg.in/square/go-jose.v2"
)

func exit(msg string, err error) {
	fmt.Fprintf(os.Stderr, "[ERROR] %s: %s\n", err)
	os.Exit(1)
}

func main() {
	key := &jose.JSONWebKey{
		KeyID: "abc123",
		Key:   []byte("super secret"),
	}
	if jtext, err := json.MarshalIndent(key, "", "  "); err == nil {
		fmt.Printf("JWS Key: %s\n", jtext)
	}

	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key}, nil)
	if err != nil {
		exit("Could not create signer", err)
	}

	jws, err := signer.Sign([]byte("This is a test"))
	if err != nil {
		exit("Could not sign", err)
	}

	compact, err := jws.CompactSerialize()
	if err != nil {
		exit("Could not compact/serialize", err)
	}
	fmt.Printf("JWS Compact Serialized: %s\n", compact)

	b64data := strings.SplitN(compact, ".", 3)
	protected, err := base64.RawURLEncoding.DecodeString(b64data[0])
	if err != nil {
		exit("Could not base64decode", err)
	}
	fmt.Printf("JWS Protected Header: %s\n", string(protected))
}
```