### PR TITLE
Preserve integers when normalizing JWT claims (fixes #142)

### DIFF
--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -18,6 +18,7 @@
 package jwt
 
 import (
+	"bytes"
 	"reflect"
 
 	"gopkg.in/square/go-jose.v2/json"
@@ -136,7 +137,11 @@ func normalize(i interface{}) (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := json.Unmarshal(raw, &m); err != nil {
+
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.UseNumber()
+
+	if err := d.Decode(&m); err != nil {
 		return nil, err
 	}
 

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+
 	"gopkg.in/square/go-jose.v2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -149,7 +150,7 @@ func ExampleSigned() {
 	}
 
 	fmt.Println(raw)
-	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsibGVlbGEiLCJmcnkiXSwiaXNzIjoiaXNzdWVyIiwibmJmIjoxLjQ1MTYwNjRlKzA5LCJzdWIiOiJzdWJqZWN0In0.mI6U-xUdttpOPIDUAI2uyg9lFgoqaAb-hwmz8L6L3fo
+	// Output: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOlsibGVlbGEiLCJmcnkiXSwiaXNzIjoiaXNzdWVyIiwibmJmIjoxNDUxNjA2NDAwLCJzdWIiOiJzdWJqZWN0In0.4PgCj0VO-uG_cb1mNA38NjJyp0N-NdGIDLoYelEkciw
 }
 
 func ExampleEncrypted() {


### PR DESCRIPTION
We normalize claims for tokens given to us in the builder by marshaling and then unmarshaling as a JSON object. However, because JSON officially only supports floating-point numbers, this loses precision for integers embedded in structs (see #142). We switch to using json.Decoder (with UseNumber option) to decode numbers into json.Number, which preserves the precise value for both integers and floats.

Go Playground example to play around with old/new code: https://play.golang.org/p/2irRfWlxgN

cc @shaxbee @jacobstr 