### PR TITLE
Prevent panics when sanitizing header values that may be nil

### DIFF
--- a/jws_test.go
+++ b/jws_test.go
@@ -310,3 +310,25 @@ func TestErrorMissingPayloadJWS(t *testing.T) {
 		t.Errorf("unexpected error message, should contain 'missing payload': %s", err)
 	}
 }
+
+// Test that a null value in the header doesn't panic
+func TestNullHeaderValue(t *testing.T) {
+	msg := `{
+   "payload":
+    "eyJpc3MiOiJqb2UiLA0KICJleHAiOjEzMDA4MTkzODAsDQogImh0dHA6Ly9leGF
+     tcGxlLmNvbS9pc19yb290Ijp0cnVlfQ",
+   "protected":"eyJhbGciOiJFUzI1NiIsIm5vbmNlIjpudWxsfQ",
+   "header":
+    {"kid":"e9bc097a-ce51-4036-9562-d2ade882db0d"},
+   "signature":
+    "DtEhU3ljbEg8L38VWAfUAqOyKAM6-Xx-F4GawxaepmXFCgfTjDxw5djxLa8IS
+     lSApmWQxfKTUJqPP3-Kg6NU1Q"
+  }`
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("ParseSigned panic'd when parsing a message with a null protected header value")
+		}
+	}()
+	ParseSigned(msg)
+}

--- a/shared.go
+++ b/shared.go
@@ -297,6 +297,9 @@ func (parsed rawHeader) getCritical() ([]string, error) {
 // sanitized produces a cleaned-up header object from the raw JSON.
 func (parsed rawHeader) sanitized() (h Header, err error) {
 	for k, v := range parsed {
+		if v == nil {
+			continue
+		}
 		switch k {
 		case headerJWK:
 			var jwk *JSONWebKey


### PR DESCRIPTION
`rawHeader.sanitized` doesn't check if the values of the map it is `range`ing over are `nil` before dereferencing them. Since `encoding/json` is happy to unmarshal the value `null` into a `nil` when the field value is a pointer this allows a message to be crafted that will cause a panic, i.e. if the protected header contains `{"alg":"ES256","nonce":null}` it will be unmarshaled into the map as `"alg": ..., "nonce": nil`.

This adds a simple check that the value of the field is non-`nil` before attempting to parse it further and a test that this fixes the panics.