### PR TITLE
Fix issue #155: expose protected/unprotected headers separately

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -52,8 +52,19 @@ type JSONWebSignature struct {
 
 // Signature represents a single signature over the JWS payload and protected header.
 type Signature struct {
-	// Header fields, such as the signature algorithm
+	// Merged header fields. Contains both protected and unprotected header
+	// values. Prefer using Protected and Unprotected fields instead of this.
+	// Values in this header may or may not have been signed and in general
+	// should not be trusted.
 	Header Header
+
+	// Protected header. Values in this header were signed and
+	// will be verified as part of the signature verification process.
+	Protected Header
+
+	// Unprotected header. Values in this header were not signed
+	// and in general should not be trusted.
+	Unprotected Header
 
 	// The actual signature value
 	Signature []byte
@@ -159,6 +170,20 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
 			return nil, err
 		}
 
+		if signature.header != nil {
+			signature.Unprotected, err = signature.header.sanitized()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if signature.protected != nil {
+			signature.Protected, err = signature.protected.sanitized()
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		// As per RFC 7515 Section 4.1.3, only public keys are allowed to be embedded.
 		jwk := signature.Header.JSONWebKey
 		if jwk != nil && (!jwk.Valid() || !jwk.IsPublic()) {
@@ -186,6 +211,20 @@ func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
 		obj.Signatures[i].Header, err = obj.Signatures[i].mergedHeaders().sanitized()
 		if err != nil {
 			return nil, err
+		}
+
+		if obj.Signatures[i].header != nil {
+			obj.Signatures[i].Unprotected, err = obj.Signatures[i].header.sanitized()
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if obj.Signatures[i].protected != nil {
+			obj.Signatures[i].Protected, err = obj.Signatures[i].protected.sanitized()
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		obj.Signatures[i].Signature = sig.Signature.bytes()

--- a/jws_test.go
+++ b/jws_test.go
@@ -300,6 +300,45 @@ func TestSampleNimbusJWSMessagesHMAC(t *testing.T) {
 	}
 }
 
+func TestHeaderFieldsCompact(t *testing.T) {
+	msg := "eyJhbGciOiJFUzUxMiJ9.TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ.AeYNFC1rwIgQv-5fwd8iRyYzvTaSCYTEICepgu9gRId-IW99kbSVY7yH0MvrQnqI-a0L8zwKWDR35fW5dukPAYRkADp3Y1lzqdShFcEFziUVGo46vqbiSajmKFrjBktJcCsfjKSaLHwxErF-T10YYPCQFHWb2nXJOOI3CZfACYqgO84g"
+
+	obj, err := ParseSigned(msg)
+	if err != nil {
+		t.Fatal("unable to parse message", msg, err)
+	}
+	if obj.Signatures[0].Header.Algorithm != "ES512" {
+		t.Error("merged header did not contain expected alg value")
+	}
+	if obj.Signatures[0].Protected.Algorithm != "ES512" {
+		t.Error("protected header did not contain expected alg value")
+	}
+	if obj.Signatures[0].Unprotected.Algorithm != "" {
+		t.Error("unprotected header contained an alg value")
+	}
+}
+
+func TestHeaderFieldsFull(t *testing.T) {
+	msg := `{"payload":"TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQ","protected":"eyJhbGciOiJFUzUxMiJ9","header":{"custom":"test"},"signature":"AeYNFC1rwIgQv-5fwd8iRyYzvTaSCYTEICepgu9gRId-IW99kbSVY7yH0MvrQnqI-a0L8zwKWDR35fW5dukPAYRkADp3Y1lzqdShFcEFziUVGo46vqbiSajmKFrjBktJcCsfjKSaLHwxErF-T10YYPCQFHWb2nXJOOI3CZfACYqgO84g"}`
+
+	obj, err := ParseSigned(msg)
+	if err != nil {
+		t.Fatal("unable to parse message", msg, err)
+	}
+	if obj.Signatures[0].Header.Algorithm != "ES512" {
+		t.Error("merged header did not contain expected alg value")
+	}
+	if obj.Signatures[0].Protected.Algorithm != "ES512" {
+		t.Error("protected header did not contain expected alg value")
+	}
+	if obj.Signatures[0].Unprotected.Algorithm != "" {
+		t.Error("unprotected header contained an alg value")
+	}
+	if obj.Signatures[0].Unprotected.ExtraHeaders["custom"] != "test" {
+		t.Error("unprotected header did not contain custom header value")
+	}
+}
+
 // Test vectors generated with nimbus-jose-jwt
 func TestErrorMissingPayloadJWS(t *testing.T) {
 	_, err := (&rawJSONWebSignature{}).sanitized()


### PR DESCRIPTION
Expose protected/unprotected headers separately so callers can distinguish between values that were protected vs. unprotected. cc @jsha 