### PR TITLE
Use consistent types for ed25519.PrivateKey and ed25519.PublicKey

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -247,7 +247,7 @@ func (k *JSONWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 // IsPublic returns true if the JWK represents a public key (not symmetric, not private).
 func (k *JSONWebKey) IsPublic() bool {
 	switch k.Key.(type) {
-	case *ecdsa.PublicKey, *rsa.PublicKey, *ed25519.PublicKey:
+	case *ecdsa.PublicKey, *rsa.PublicKey, ed25519.PublicKey:
 		return true
 	default:
 		return false
@@ -276,12 +276,12 @@ func (k *JSONWebKey) Valid() bool {
 		if key.N == nil || key.E == 0 || key.D == nil || len(key.Primes) < 2 {
 			return false
 		}
-	case *ed25519.PublicKey:
-		if len(*key) != 32 {
+	case ed25519.PublicKey:
+		if len(key) != 32 {
 			return false
 		}
-	case *ed25519.PrivateKey:
-		if len(*key) != 64 {
+	case ed25519.PrivateKey:
+		if len(key) != 64 {
 			return false
 		}
 	default:

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -657,8 +657,8 @@ func TestJWKIsPublic(t *testing.T) {
 		{&ecdsa.PrivateKey{eccPub, bigInt}, false},
 		{&rsaPub, true},
 		{&rsa.PrivateKey{rsaPub, bigInt, []*big.Int{bigInt, bigInt}, rsa.PrecomputedValues{}}, false},
-		{&ed25519PublicKey, true},
-		{&ed25519PrivateKey, false},
+		{ed25519PublicKey, true},
+		{ed25519PrivateKey, false},
 	}
 
 	for _, tc := range cases {
@@ -689,10 +689,10 @@ func TestJWKValid(t *testing.T) {
 		{&rsaPub, true},
 		{&rsa.PrivateKey{}, false},
 		{&rsa.PrivateKey{rsaPub, bigInt, []*big.Int{bigInt, bigInt}, rsa.PrecomputedValues{}}, true},
-		{&ed25519PublicKey, true},
-		{&ed25519PrivateKey, true},
-		{&edPubEmpty, false},
-		{&edPrivEmpty, false},
+		{ed25519PublicKey, true},
+		{ed25519PrivateKey, true},
+		{edPubEmpty, false},
+		{edPrivEmpty, false},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Since these are already bytes slices, we shouldn't be using pointers to them.  This is different than most of the other key types, since they are generally realized structs.