### PR TITLE
JWK key generator tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ standard where possible. The Godoc reference has a list of constants.
  RSASSA-PSS                 | PS256, PS384, PS512
  HMAC                       | HS256, HS384, HS512
  ECDSA                      | ES256, ES384, ES512
+ Ed25519                    | EdDSA
 
  Content encryption         | Algorithm identifier(s)
  :------------------------- | :------------------------------

--- a/jose-util/README.md
+++ b/jose-util/README.md
@@ -11,7 +11,7 @@ The utility includes the subcommands `encrypt`, `decrypt`, `sign`, `verify` and
 
 Algorithms are selected via the `--alg` and `--enc` flags, which influence the
 `alg` and `enc` headers in respectively. For JWE, `--alg` specifies the key
-managment algorithm (e.g. `RSA-OAEP`) and `--enc` specifies the content
+management algorithm (e.g. `RSA-OAEP`) and `--enc` specifies the content
 encryption algorithm (e.g. `A128GCM`). For JWS, `--alg` specifies the
 signature algorithm (e.g. `PS256`).
 

--- a/jose-util/README.md
+++ b/jose-util/README.md
@@ -23,7 +23,7 @@ message, but it's possible to get the full serialization by supplying the
 
 Keys are specified via the `--key` flag. Supported key types are naked RSA/EC
 keys and X.509 certificates with embedded RSA/EC keys. Keys must be in PEM
-or DER formats.
+or DER formats. JWK format produced by `jwk-keygen` is also supported.
 
 ## Examples
 

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -117,7 +117,7 @@ func main() {
 		writeOutput(*outFile, []byte(msg))
 	case "verify":
 		verificationKey, err := LoadPublicKey(keyBytes)
-		exitOnError(err, "unable to read private key")
+		exitOnError(err, "unable to read public key")
 
 		obj, err := jose.ParseSigned(string(readInput(*inFile)))
 		exitOnError(err, "unable to parse message")

--- a/jose-util/utils.go
+++ b/jose-util/utils.go
@@ -19,10 +19,27 @@ package main
 import (
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"gopkg.in/square/go-jose.v2"
 )
 
-// LoadPublicKey loads a public key from PEM/DER-encoded data.
+func LoadJSONWebKey(json []byte, pub bool) (*jose.JSONWebKey, error) {
+	var jwk jose.JSONWebKey
+	err := jwk.UnmarshalJSON(json)
+	if err != nil {
+		return nil, err
+	}
+	if !jwk.Valid() {
+		return nil, errors.New("invalid JWK key")
+	}
+	if jwk.IsPublic() != pub {
+		return nil, errors.New("priv/pub JWK key mismatch")
+	}
+	return &jwk, nil
+}
+
+// LoadPublicKey loads a public key from PEM/DER/JWK-encoded data.
 func LoadPublicKey(data []byte) (interface{}, error) {
 	input := data
 
@@ -42,10 +59,15 @@ func LoadPublicKey(data []byte) (interface{}, error) {
 		return cert.PublicKey, nil
 	}
 
-	return nil, fmt.Errorf("square/go-jose: parse error, got '%s' and '%s'", err0, err1)
+	jwk, err2 := LoadJSONWebKey(data, true)
+	if err2 == nil {
+		return jwk, nil
+	}
+
+	return nil, fmt.Errorf("square/go-jose: parse error, got '%s', '%s' and '%s'", err0, err1, err2)
 }
 
-// LoadPrivateKey loads a private key from PEM/DER-encoded data.
+// LoadPrivateKey loads a private key from PEM/DER/JWK-encoded data.
 func LoadPrivateKey(data []byte) (interface{}, error) {
 	input := data
 
@@ -70,5 +92,10 @@ func LoadPrivateKey(data []byte) (interface{}, error) {
 		return priv, nil
 	}
 
-	return nil, fmt.Errorf("square/go-jose: parse error, got '%s', '%s' and '%s'", err0, err1, err2)
+	jwk, err3 := LoadJSONWebKey(input, false)
+	if err3 == nil {
+		return jwk, nil
+	}
+
+	return nil, fmt.Errorf("square/go-jose: parse error, got '%s', '%s', '%s' and '%s'", err0, err1, err2, err3)
 }

--- a/jwk-keygen/README.md
+++ b/jwk-keygen/README.md
@@ -1,0 +1,35 @@
+# JWK Key Generator
+
+The `jwk-keygen` command line utility generates keypairs used for asymmetric
+encryption and signing algorithms in JSON Web Key (JWK) format.
+
+## Usage
+
+The utility requires specification of both desired algorithm (`alg`) and key
+usage (`use`) to remind that same keypair should never be used both for
+encryption and signing.
+
+Algorithms are selected via the `--alg` flag, which influence the `alg` header.
+For JWE (`--use=enc`), `--alg` specifies the key management algorithm (e.g.
+`RSA-OAEP`).  . For JWS (`--use=sig`), `--alg` specifies the signature
+algorithm (e.g. `PS256`).
+
+Output file is determined by specified usage, algorithm and Key ID, e.g.
+`jwk-keygen --use=sig --alg=RS512 --kid=test` produces files
+`jwk_sig_RS512_test` and `jwk_sig_RS512_test.pub`. Keys are sent to stdout when
+no Key ID is specified: neither pre-defined nor random one.
+
+## Examples
+
+### RSA 2048
+
+Generate RSA/2048 key for encryption and output to stdout.
+
+    jwk-keygen --use enc --alg RSA-OAEP
+
+### Custom key length
+
+Generate RSA/4096 key for signing and store to files.
+
+    jwk-keygen --use sig --alg RS256 --bits 4096 --kid test
+

--- a/jwk-keygen/README.md
+++ b/jwk-keygen/README.md
@@ -11,8 +11,8 @@ encryption and signing.
 
 Algorithms are selected via the `--alg` flag, which influence the `alg` header.
 For JWE (`--use=enc`), `--alg` specifies the key management algorithm (e.g.
-`RSA-OAEP`).  . For JWS (`--use=sig`), `--alg` specifies the signature
-algorithm (e.g. `PS256`).
+`RSA-OAEP`). For JWS (`--use=sig`), `--alg` specifies the signature algorithm
+(e.g. `PS256`).
 
 Output file is determined by specified usage, algorithm and Key ID, e.g.
 `jwk-keygen --use=sig --alg=RS512 --kid=test` produces files

--- a/jwk-keygen/main.go
+++ b/jwk-keygen/main.go
@@ -1,0 +1,183 @@
+/*-
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base32"
+	"errors"
+	"fmt"
+	"golang.org/x/crypto/ed25519"
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/square/go-jose.v2"
+)
+
+var (
+	app = kingpin.New("jwk-keygen", "A command-line utility to generate public/pirvate keypairs in JWK format.")
+
+	use = app.Flag("use", "Desrired key use").Required().Enum("enc", "sig")
+	alg = app.Flag("alg", "Generate key to be used for ALG").Required().Enum(
+		// `sig`
+		string(jose.ES256), string(jose.ES384), string(jose.ES512), string(jose.EdDSA),
+		string(jose.RS256), string(jose.RS384), string(jose.RS512), string(jose.PS256), string(jose.PS384), string(jose.PS512),
+		// `enc`
+		string(jose.RSA1_5), string(jose.RSA_OAEP), string(jose.RSA_OAEP_256),
+		string(jose.ECDH_ES), string(jose.ECDH_ES_A128KW), string(jose.ECDH_ES_A192KW), string(jose.ECDH_ES_A256KW),
+	)
+	bits    = app.Flag("bits", "Key size in bits").Int()
+	kid     = app.Flag("kid", "Key ID").String()
+	kidRand = app.Flag("kid-rand", "Generate random Key ID").Bool()
+)
+
+// KeygenSig generates keypair for corresponding SignatureAlgorithm.
+func KeygenSig(alg jose.SignatureAlgorithm, bits int) (crypto.PublicKey, crypto.PrivateKey, error) {
+	switch alg {
+	case jose.ES256, jose.ES384, jose.ES512, jose.EdDSA:
+		keylen := map[jose.SignatureAlgorithm]int{
+			jose.ES256: 256,
+			jose.ES384: 384,
+			jose.ES512: 521, // sic!
+			jose.EdDSA: 256,
+		}
+		if bits != 0 && bits != keylen[alg] {
+			return nil, nil, errors.New("this `alg` does not support arbitrary key length")
+		}
+	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
+		if bits == 0 {
+			bits = 2048
+		}
+		if bits < 2048 {
+			return nil, nil, errors.New("too short key for RSA `alg`, 2048+ is required")
+		}
+	}
+	switch alg {
+	case jose.ES256:
+		// The cryptographic operations are implemented using constant-time algorithms.
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		return key.Public(), key, err
+	case jose.ES384:
+		// NB: The cryptographic operations do not use constant-time algorithms.
+		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		return key.Public(), key, err
+	case jose.ES512:
+		// NB: The cryptographic operations do not use constant-time algorithms.
+		key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		return key.Public(), key, err
+	case jose.EdDSA:
+		pub, key, err := ed25519.GenerateKey(rand.Reader)
+		return pub, key, err
+	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
+		key, err := rsa.GenerateKey(rand.Reader, bits)
+		return key.Public(), key, err
+	default:
+		return nil, nil, errors.New("unknown `alg` for `use` = `sig`")
+	}
+}
+
+// KeygenEnc generates keypair for corresponding KeyAlgorithm.
+func KeygenEnc(alg jose.KeyAlgorithm, bits int) (crypto.PublicKey, crypto.PrivateKey, error) {
+	switch alg {
+	case jose.RSA1_5, jose.RSA_OAEP, jose.RSA_OAEP_256:
+		if bits == 0 {
+			bits = 2048
+		}
+		if bits < 2048 {
+			return nil, nil, errors.New("too short key for RSA `alg`, 2048+ is required")
+		}
+		key, err := rsa.GenerateKey(rand.Reader, bits)
+		return key.Public(), key, err
+	case jose.ECDH_ES, jose.ECDH_ES_A128KW, jose.ECDH_ES_A192KW, jose.ECDH_ES_A256KW:
+		var crv elliptic.Curve
+		switch bits {
+		case 0, 256:
+			crv = elliptic.P256()
+		case 384:
+			crv = elliptic.P384()
+		case 521:
+			crv = elliptic.P521()
+		default:
+			return nil, nil, errors.New("unknown elliptic curve bit length, use one of 256, 384, 521")
+		}
+		key, err := ecdsa.GenerateKey(crv, rand.Reader)
+		return key.Public(), key, err
+	default:
+		return nil, nil, errors.New("unknown `alg` for `use` = `enc`")
+	}
+}
+
+func main() {
+	app.Version("v2")
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	if *kidRand {
+		if *kid == "" {
+			b := make([]byte, 5)
+			_, err := rand.Read(b)
+			app.FatalIfError(err, "can't Read() crypto/rand")
+			*kid = base32.StdEncoding.EncodeToString(b)
+		} else {
+			app.FatalUsage("can't combine --kid and --kid-rand")
+		}
+	}
+
+	var privKey crypto.PublicKey
+	var pubKey crypto.PrivateKey
+	var err error
+	switch *use {
+	case "sig":
+		pubKey, privKey, err = KeygenSig(jose.SignatureAlgorithm(*alg), *bits)
+	case "enc":
+		pubKey, privKey, err = KeygenEnc(jose.KeyAlgorithm(*alg), *bits)
+	}
+	app.FatalIfError(err, "unable to generate key")
+
+	priv := jose.JSONWebKey{Key: privKey, KeyID: *kid, Algorithm: *alg, Use: *use}
+	pub := jose.JSONWebKey{Key: pubKey, KeyID: *kid, Algorithm: *alg, Use: *use}
+
+	if priv.IsPublic() || !pub.IsPublic() || !priv.Valid() || !pub.Valid() {
+		app.Fatalf("invalid keys were generated")
+	}
+
+	privJS, err := priv.MarshalJSON()
+	app.FatalIfError(err, "can't Marshal private key to JSON")
+	pubJS, err := pub.MarshalJSON()
+	app.FatalIfError(err, "can't Marshal public key to JSON")
+
+	if *kid == "" {
+		fmt.Printf("==> jwk_%s.pub <==\n", *alg)
+		fmt.Println(string(pubJS))
+		fmt.Printf("==> jwk_%s <==\n", *alg)
+		fmt.Println(string(privJS))
+	} else {
+		// JWK Thumbprint (RFC7638) is not used for key id because of
+		// lack of canonical representation.
+		fname := fmt.Sprintf("jwk_%s_%s_%s", *use, *alg, *kid)
+		err = ioutil.WriteFile(fname+".pub", pubJS, 0444)
+		app.FatalIfError(err, "can't write public key to file %s.pub", fname)
+		fmt.Printf("Written public key to %s.pub\n", fname)
+		err = ioutil.WriteFile(fname, privJS, 0400)
+		app.FatalIfError(err, "cant' write private key to file %s", fname)
+		fmt.Printf("Written private key to %s\n", fname)
+	}
+}

--- a/jwk.go
+++ b/jwk.go
@@ -254,6 +254,25 @@ func (k *JSONWebKey) IsPublic() bool {
 	}
 }
 
+// Public creates JSONWebKey with corresponding publik key if JWK represents asymmetric private key.
+func (k *JSONWebKey) Public() JSONWebKey {
+	if k.IsPublic() {
+		return *k
+	}
+	ret := *k
+	switch key := k.Key.(type) {
+	case *ecdsa.PrivateKey:
+		ret.Key = key.Public()
+	case *rsa.PrivateKey:
+		ret.Key = key.Public()
+	case ed25519.PrivateKey:
+		ret.Key = key.Public()
+	default:
+		return JSONWebKey{} // returning invalid key
+	}
+	return ret
+}
+
 // Valid checks that the key contains the expected parameters.
 func (k *JSONWebKey) Valid() bool {
 	if k.Key == nil {

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -697,8 +697,19 @@ func TestJWKValid(t *testing.T) {
 
 	for _, tc := range cases {
 		k := &JSONWebKey{Key: tc.key}
-		if valid := k.Valid(); valid != tc.expectedValidity {
+		valid := k.Valid()
+		if valid != tc.expectedValidity {
 			t.Errorf("expected Valid to return %t, got %t", tc.expectedValidity, valid)
+		}
+		if valid {
+			wasPublic := k.IsPublic()
+			p := k.Public() // all aforemention keys are asymmetric
+			if !p.Valid() {
+				t.Errorf("unable to derive public key from valid asymmetric key")
+			}
+			if wasPublic != k.IsPublic() {
+				t.Errorf("original key was touched during public key derivation")
+			}
 		}
 	}
 }


### PR DESCRIPTION
I'm adding this key generator as JWK has canonical representation, so util to generate alike keys sounds like something useful to go-jose project.

I'm going to use this key format for my patch for [heipei/nginx-sso](https://github.com/heipei/nginx-sso) so I can also move it there, but I feel like go-jose is right place for this generator.

`Public()` method is added to be able to load private key during application initialization and use it's public part in part of the application that do not require private key, e.g. when the daemon issues signed token to the browser and checks signature in some of code paths.

Also, I've electronically signed [Individual Contributor License Agreement][1].

 [1]: https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1