### PR TITLE
Supply custom ECDH key and apu/apv claims

### DIFF
--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 
 	"gopkg.in/alecthomas/kingpin.v2"
-	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/NeilMadden/go-jose.v2"
 )
 
 var (

--- a/jwk.go
+++ b/jwk.go
@@ -31,7 +31,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 )
 
 // rawJSONWebKey represents a public or private key in JWK format, used for parsing/serializing.

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -30,7 +30,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 )
 
 // Test chain of two X.509 certificates

--- a/jws.go
+++ b/jws.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"strings"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 )
 
 // rawJSONWebSignature represents a raw JWS JSON object. Used for parsing/serializing.

--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -21,9 +21,9 @@ import (
 	"bytes"
 	"reflect"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 
-	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/NeilMadden/go-jose.v2"
 )
 
 // Builder is a utility for making JSON Web Tokens. Calls can be chained, and

--- a/jwt/builder_test.go
+++ b/jwt/builder_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 )
 
 type testClaims struct {

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -26,8 +26,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"gopkg.in/NeilMadden/go-jose.v2"
+	"gopkg.in/NeilMadden/go-jose.v2/jwt"
 )
 
 var sharedKey = []byte("secret")

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -18,8 +18,8 @@
 package jwt
 
 import (
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 	"strings"
 )
 

--- a/shared.go
+++ b/shared.go
@@ -21,7 +21,7 @@ import (
 	"errors"
 	"fmt"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 )
 
 // KeyAlgorithm represents a key management algorithm.

--- a/signing.go
+++ b/signing.go
@@ -25,7 +25,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 )
 
 // NonceSource represents a source of random nonces to go into JWS objects

--- a/signing_test.go
+++ b/signing_test.go
@@ -26,7 +26,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/square/go-jose.v2/json"
+	"gopkg.in/NeilMadden/go-jose.v2/json"
 )
 
 type staticNonceSource string

--- a/symmetric.go
+++ b/symmetric.go
@@ -29,7 +29,7 @@ import (
 	"hash"
 	"io"
 
-	"gopkg.in/square/go-jose.v2/cipher"
+	"gopkg.in/NeilMadden/go-jose.v2/cipher"
 )
 
 // Random reader (stubbed out in tests)


### PR DESCRIPTION
NB: this PR needs a bit of work to get it into a mergeable state but I wanted to put it up for your feedback. I have the go-ahead from my employer wrt to the contributor agreement.

This adds two new encryptor options: one provides a callback for generating the apu and apv values and is handed the public keys for both parties; the other allows the caller to specify a custom ephemeral key generator.

For an illustration of the kinds of issues that populating the apu and apv claims is meant to solve, see for instance the rationale for the [TLS extended master secret in response to the Triple Handshake vulnerability](https://www.imperialviolet.org/2014/03/03/triplehandshake.html). In this case, including too little information in the key derivation hash process was identified as the root cause and so the extended master secret was developed that hashes in the full transcript of the TLS handshake up to that point. In particular, you should always at least include the public keys in the KDF hash, hence why we make them available to the callback.

The second change to allow a custom ephemeral key to be provided is to support including a signed hash of the ephemeral public key in the payload of the JWE to authenticate the ephemeral public key. Otherwise, the ephemeral key is generated too late in the process for this to happen so we generate it up front and then supply it to the ECDH key agreement process via this callback.

Let me know if you have comments/feedback. I'm not precious about the approach, so happy to rework if you'd prefer a different design. In the meantime, I'll change the imports back and add some tests.