### PR TITLE
Allow empty signature

### DIFF
--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -78,3 +78,16 @@ func TestDecodeClaims(t *testing.T) {
 		assert.Equal(t, v.Err, json.Unmarshal([]byte(v.Raw), &c))
 	}
 }
+
+func TestEmptySignature(t *testing.T) {
+	var empty []byte
+	s := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0."
+	wt, err := ParseSigned(s)
+	if err != nil {
+		t.Errorf("Failed to parse jws: %#v", err)
+	}
+	out := make(map[string]interface{})
+	if err := wt.Claims(empty, &out); err != nil {
+		t.Errorf("Claim with no signature failed: %#v", err)
+	}
+}

--- a/signing.go
+++ b/signing.go
@@ -302,6 +302,9 @@ func (obj JSONWebSignature) Verify(verificationKey interface{}) ([]byte, error) 
 
 	input := obj.computeAuthData(&signature)
 	alg := headers.getSignatureAlgorithm()
+	if len(signature.Signature) == 0 {
+		return obj.payload, nil
+	}
 	err = verifier.verifyPayload(input, signature.Signature, alg)
 	if err == nil {
 		return obj.payload, nil


### PR DESCRIPTION
When I was using this library for work I was getting the error `square/go-jose: error in cryptographic primitive`. Firstly we use the [this](https://github.com/jwt/ruby-jwe) ruby library on our rails server. We have an asymmetric key pair and encrypt JWTs like something like this 
```
# no password on the jwt
jwt = JWT.encode(self, nil, 'none')
# => "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJpc3MiOiJPQXV0aCIsImV4cCI6MTUxODE1MTQwM30."
jwe = JWE.encrypt(jwt, public_key)

```
Even on their [readme](https://github.com/jwt/ruby-jwt#algorithms-and-usage) it shows a similar jwt,
`eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJkYXRhIjoidGVzdCJ9.`

But when I would try to use this library I was getting an error.

```
 var noPassword []byte
  tok, err := jose.ParseEncrypted(s)
  if err != nil {
    fmt.Printf("error parsing jwe: %v ", err)
  }

  nested, err := tok.Decrypt(d.PrivateKey)
  if err != nil {
    fmt.Printf("error decrypting jwe: %v ", err)
  }

  wt, err := jwt.ParseSigned(string(nested))
  if err != nil {
    fmt.Printf("error serializing into jwt: %v ", err)
    return user, err
  }

  claims := make(map[string]interface{})
  if err := wt.Claims(noPassword, &claims); err != nil {
    fmt.Printf("error serializing claims: %v ", err)
    // Here I was getting the error square/go-jose: error in cryptographic primitive
  }
```
I might be doing things wrong here and if so let me know, but this fixes things for my use case. 
