### PR TITLE
Make v1 tests pass with Go 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,12 @@ matrix:
     - go: tip
 
 go:
-- 1.3
-- 1.4
-- 1.5
-- 1.6
-- 1.7
-- tip
+- '1.5.x'
+- '1.6.x'
+- '1.7.x'
+- '1.8.x'
+- '1.9.x'
+- '1.10.x'
 
 go_import_path: gopkg.in/square/go-jose.v1
 

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -606,13 +606,13 @@ func TestJWKSymmetricRoundtrip(t *testing.T) {
 	jwk1 := JsonWebKey{Key: []byte{1, 2, 3, 4}}
 	marshaled, err := jwk1.MarshalJSON()
 	if err != nil {
-		t.Errorf("failed to marshal valid JWK object", err)
+		t.Errorf("failed to marshal valid JWK object: %s", err)
 	}
 
 	var jwk2 JsonWebKey
 	err = jwk2.UnmarshalJSON(marshaled)
 	if err != nil {
-		t.Errorf("failed to unmarshal valid JWK object", err)
+		t.Errorf("failed to unmarshal valid JWK object: %s", err)
 	}
 
 	if !bytes.Equal(jwk1.Key.([]byte), jwk2.Key.([]byte)) {


### PR DESCRIPTION
Make v1 tests pass with Go 1.10, fixes #176.