### PR TITLE
fixing examples.

### DIFF
--- a/jose-util/README.md
+++ b/jose-util/README.md
@@ -31,25 +31,25 @@ or DER formats.
 
 Takes a plaintext as input, encrypts, and prints the encrypted message.
 
-    jose-util encrypt -k public-key.pem --alg RSA-OAEP --enc A128GCM
+    echo 'test message' | jose-util encrypt --key public-key.pem --alg RSA-OAEP --enc A128GCM
 
 ### Decrypt
 
 Takes an encrypted message (JWE) as input, decrypts, and prints the plaintext.
 
-    jose-util decrypt -k private-key.pem
+    jose-util decrypt --key private-key.pem
 
 ### Sign
 
 Takes a payload as input, signs it, and prints the signed message with the embedded payload.
 
-    jose-util sign -k private-key.pem --alg PS256
+    jose-util sign --key private-key.pem --alg PS256
 
 ### Verify
 
 Reads a signed message (JWS), verifies it, and extracts the payload.
 
-    jose-util verify -k public-key.pem
+    jose-util verify --key public-key.pem
 
 ### Expand
 


### PR DESCRIPTION
`-k` short flag doesn't work. Changed examples to `--key`
Provided an example of piping output of echo to jose-util