### PR TITLE
A potential fix for #169: Get claims from jwt even if validation fails

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -37,9 +37,6 @@ type NestedJSONWebToken struct {
 // Claims deserializes a JSONWebToken into dest using the provided key.
 func (t *JSONWebToken) Claims(key interface{}, dest ...interface{}) error {
 	b, err := t.payload(key)
-	if err != nil {
-		return err
-	}
 
 	for _, d := range dest {
 		if err := json.Unmarshal(b, d); err != nil {
@@ -47,7 +44,7 @@ func (t *JSONWebToken) Claims(key interface{}, dest ...interface{}) error {
 		}
 	}
 
-	return nil
+	return err
 }
 
 func (t *NestedJSONWebToken) Decrypt(decryptionKey interface{}) (*JSONWebToken, error) {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -40,6 +40,30 @@ type customClaims struct {
 	Scopes []string `json:"scopes,omitempty"`
 }
 
+func TestGetClaimsInvalid(t *testing.T) {
+	tok, err := ParseSigned(hmacSignedToken)
+	if assert.NoError(t, err, "Error parsing signed token.") {
+		c := &Claims{}
+		c2 := &customClaims{}
+
+		err := tok.Claims(nil, c, c2)
+		if err == nil {
+			t.Errorf("Error expected")
+		}
+		assert.Equal(t, "subject", c.Subject)
+		assert.Equal(t, "issuer", c.Issuer)
+		assert.Equal(t, []string{"s1", "s2"}, c2.Scopes)
+
+		err = tok.Claims([]byte("wrongkey"), c, c2)
+		if err == nil {
+			t.Errorf("Error expected")
+		}
+		assert.Equal(t, "subject", c.Subject)
+		assert.Equal(t, "issuer", c.Issuer)
+		assert.Equal(t, []string{"s1", "s2"}, c2.Scopes)
+	}
+}
+
 func TestDecodeToken(t *testing.T) {
 	tok, err := ParseSigned(hmacSignedToken)
 	if assert.NoError(t, err, "Error parsing signed token.") {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -40,27 +40,28 @@ type customClaims struct {
 	Scopes []string `json:"scopes,omitempty"`
 }
 
-func TestGetClaimsInvalid(t *testing.T) {
+func TestGetClaimsWithoutVerification(t *testing.T) {
 	tok, err := ParseSigned(hmacSignedToken)
 	if assert.NoError(t, err, "Error parsing signed token.") {
 		c := &Claims{}
 		c2 := &customClaims{}
 
-		err := tok.Claims(nil, c, c2)
-		if err == nil {
-			t.Errorf("Error expected")
+		err := tok.UnsafeClaimsWithoutVerification(c, c2)
+		if err != nil {
+			t.Errorf("Error not expected: %s", err)
 		}
 		assert.Equal(t, "subject", c.Subject)
 		assert.Equal(t, "issuer", c.Issuer)
 		assert.Equal(t, []string{"s1", "s2"}, c2.Scopes)
 
-		err = tok.Claims([]byte("wrongkey"), c, c2)
+	}
+	tok, err = ParseEncrypted(hmacEncryptedToken)
+	if assert.NoError(t, err, "Error parsing encrypted token.") {
+		c := Claims{}
+		err := tok.UnsafeClaimsWithoutVerification(c)
 		if err == nil {
 			t.Errorf("Error expected")
 		}
-		assert.Equal(t, "subject", c.Subject)
-		assert.Equal(t, "issuer", c.Issuer)
-		assert.Equal(t, []string{"s1", "s2"}, c2.Scopes)
 	}
 }
 

--- a/signing.go
+++ b/signing.go
@@ -290,14 +290,18 @@ func (ctx *genericSigner) Options() SignerOptions {
 // payload header. You cannot assume that the key received in a payload is
 // trusted.
 func (obj JSONWebSignature) Verify(verificationKey interface{}) ([]byte, error) {
-	if verificationKey == nil {
-		return obj.payload, errors.New("square/go-jose: cannot verify without a key")
-	}
 	err := obj.DetachedVerify(obj.payload, verificationKey)
 	if err != nil {
-		return obj.payload, err
+		return nil, err
 	}
 	return obj.payload, nil
+}
+
+// UnsafePayloadWithoutVerification returns the payload without
+// verifying it. The content returned from this function cannot be
+// trusted.
+func (obj JSONWebSignature) UnsafePayloadWithoutVerification() []byte {
+	return obj.payload
 }
 
 // DetachedVerify validates a detached signature on the given payload. In

--- a/signing.go
+++ b/signing.go
@@ -290,9 +290,12 @@ func (ctx *genericSigner) Options() SignerOptions {
 // payload header. You cannot assume that the key received in a payload is
 // trusted.
 func (obj JSONWebSignature) Verify(verificationKey interface{}) ([]byte, error) {
+	if verificationKey == nil {
+		return obj.payload, errors.New("square/go-jose: cannot verify without a key")
+	}
 	err := obj.DetachedVerify(obj.payload, verificationKey)
 	if err != nil {
-		return nil, err
+		return obj.payload, err
 	}
 	return obj.payload, nil
 }


### PR DESCRIPTION
If invalid or nil key is passed, Claims() returns unmarshaled claims along with a non-nil error. 