### PR TITLE
Check inputs before calling AEAD decrypt

### DIFF
--- a/symmetric.go
+++ b/symmetric.go
@@ -212,6 +212,10 @@ func (ctx aeadContentCipher) decrypt(key, aad []byte, parts *aeadParts) ([]byte,
 		return nil, err
 	}
 
+	if len(parts.iv) < aead.NonceSize() || len(parts.tag) < ctx.authtagBytes {
+		return nil, ErrCryptoFailure
+	}
+
 	return aead.Open(nil, parts.iv, append(parts.ciphertext, parts.tag...), aad)
 }
 

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -83,6 +83,15 @@ func TestStaticKeyGen(t *testing.T) {
 	}
 }
 
+func TestAeadInvalidInput(t *testing.T) {
+	aead := newAESGCM(16).(*aeadContentCipher)
+	key := []byte("1234567890123456")
+	_, err := aead.decrypt(key, []byte{}, &aeadParts{[]byte{}, []byte{}, []byte{}})
+	if err != ErrCryptoFailure {
+		t.Error("should handle aead failure")
+	}
+}
+
 func TestVectorsAESGCM(t *testing.T) {
 	// Source: http://tools.ietf.org/html/draft-ietf-jose-json-web-encryption-29#appendix-A.1
 	plaintext := []byte{


### PR DESCRIPTION
Unfortunately the standard lib’s AES-GCM panics if the inputs are too short instead of returning an error, see issue #182. Will cherry-pick this fix into v1 after merge also since I’m pretty sure it has the same problem.