### PR TITLE
Fix panic on invalid nonce in JWE

### DIFF
--- a/symmetric.go
+++ b/symmetric.go
@@ -212,7 +212,7 @@ func (ctx aeadContentCipher) decrypt(key, aad []byte, parts *aeadParts) ([]byte,
 		return nil, err
 	}
 
-	if len(parts.iv) < aead.NonceSize() || len(parts.tag) < ctx.authtagBytes {
+	if len(parts.iv) != aead.NonceSize() || len(parts.tag) < ctx.authtagBytes {
 		return nil, ErrCryptoFailure
 	}
 

--- a/symmetric_test.go
+++ b/symmetric_test.go
@@ -84,11 +84,17 @@ func TestStaticKeyGen(t *testing.T) {
 }
 
 func TestAeadInvalidInput(t *testing.T) {
-	aead := newAESGCM(16).(*aeadContentCipher)
-	key := []byte("1234567890123456")
-	_, err := aead.decrypt(key, []byte{}, &aeadParts{[]byte{}, []byte{}, []byte{}})
-	if err != ErrCryptoFailure {
-		t.Error("should handle aead failure")
+	sample := []byte("1234567890123456")
+	tt := []aeadParts{
+		{},
+		{iv: sample, tag: sample},
+	}
+	for _, tc := range tt {
+		aead := newAESGCM(16).(*aeadContentCipher)
+		_, err := aead.decrypt(sample, []byte{}, &tc)
+		if err != ErrCryptoFailure {
+			t.Error("should handle aead failure")
+		}
 	}
 }
 


### PR DESCRIPTION
AES GCM `Open` method requires that the nonce should be a [strictly defined size](https://github.com/golang/go/blob/b3562658fddef6e9008379cac16c04c26784b7ed/src/crypto/aes/aes_gcm.go#L138-L140).
So it is still possible to tamper data and get panic.
This PR fixes this.