### PR TITLE
Support for non native Golang keys, non standard algorithms and alternate entropy sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ allows attaching a key id.
  ECDH, ECDSA                | *[ecdsa.PublicKey](http://golang.org/pkg/crypto/ecdsa/#PublicKey), *[ecdsa.PrivateKey](http://golang.org/pkg/crypto/ecdsa/#PrivateKey)
  AES, HMAC                  | []byte
 
+Additional key types non-native to Go or go-jose as well as non natively supported 
+signing behaviors can be implemented using the following interfaces:
+
+* *[jose.AbstractSigner](https://godoc.org/gopkg.in/square/go-jose.v2#AbstractSigner)
+* *[jose.AbstractVerifier](https://godoc.org/gopkg.in/square/go-jose.v2#AbstractVerifier) 
+
+These interfaces can also be used to leverage entropy sources other than 
+[crypto/rand.Reader](http://golang.org/pkg/crypto/rand) as well as algorithms, 
+curves, etc. that are not natively supported by go and go-jose.
+
 ## Examples
 
 [![godoc](http://img.shields.io/badge/godoc-version_1-blue.svg?style=flat)](https://godoc.org/gopkg.in/square/go-jose.v1)

--- a/abstract_key.go
+++ b/abstract_key.go
@@ -1,0 +1,80 @@
+/*-
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+// When implemented, allows key types and signing algorithms that are not natively supported by Golang or go-jose to be
+// used for signing operations.
+//
+// Examples of such keys include those implemented by PKCS11 providers, native keys where a non native entropy source
+// must be used to generate signatures, etc.
+//
+// In the case where the signing requires specific option values (e.g. PSS Salt Length, etc.) it is the responsibility
+// of the implementer to handle these properly in the constructor of the concrete implementation of AbstractKey and in
+// its implementation of the SignPayload function.
+type AbstractSigner interface {
+	// The Key Identifier of the key to be inserted into the `kid` claim of the jose header.
+	KeyID() string
+
+	// Signs the payload of the message.
+	SignPayload(payload []byte, algorithm SignatureAlgorithm) (signature []byte, err error)
+}
+
+// Used in signing.go to provide implement the functions of the payloadSigner interface
+type abstractSigner struct {
+	signer AbstractSigner
+}
+
+func newAbstractSigner(signer AbstractSigner, algorithm SignatureAlgorithm) (rsi recipientSigInfo, err error) {
+	return recipientSigInfo{
+		sigAlg: algorithm,
+		keyID:  signer.KeyID(),
+		signer: &abstractSigner{signer: signer},
+	}, nil
+}
+
+func (ctx *abstractSigner) signPayload(payload []byte, algorithm SignatureAlgorithm) (sig Signature, err error) {
+	sig = Signature{}
+	if sig.Signature, err = ctx.signer.SignPayload(payload, algorithm); err == nil {
+		sig.protected = &rawHeader{}
+	}
+	return
+}
+
+// When implemented, allows key types and verification algorithms that are not natively supported by Golang or go-jose
+// to be used for signature verification operatins operations.
+// Examples of such keys include those implemented by PKCS11 providers, native keys where a non native entropy source
+// must be used to generate signatures, etc.
+//
+// In the case where the verifivation requires specific option values it is the responsibility of the implementer to
+// handle these properly in the constructor of the concrete implementation of AbstractKey and in its implementation of
+// the Verify function.
+type AbstractVerifier interface {
+	Verify(payload []byte, signature []byte, algorithm SignatureAlgorithm) error
+}
+
+// Used in signing.go to provide implement the functions of the payloadVerifier interface
+type abstractVerifier struct {
+	abstractVerifier AbstractVerifier
+}
+
+func newAbstractVerifier(verifier AbstractVerifier) (payloadVerifier, error) {
+	return &abstractVerifier{verifier}, nil
+}
+
+func (ctx *abstractVerifier) verifyPayload(payload []byte, signature []byte, algorithm SignatureAlgorithm) error {
+	return ctx.abstractVerifier.Verify(payload, signature, algorithm)
+}

--- a/abstract_key_test.go
+++ b/abstract_key_test.go
@@ -1,0 +1,139 @@
+/*-
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package jose
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const (
+	JwsPayload = `{"key":"value"}`
+)
+
+var Key = []byte{0x01, 0x02, 0x03, 0x04, 0x05}
+var WrongKey = []byte{0x06, 0x07, 0x08}
+
+var serialized string
+
+func TesSignWithAbstractSigner(t *testing.T) {
+	payload := []byte(JwsPayload)
+	key, _ := NewXorTestKey(Key)
+	if signer, err := NewSigner(PS256, key); err != nil {
+		t.Errorf("Error creating signer: %q", err)
+	} else if _, err := signer.Sign(payload); err != ErrUnsupportedAlgorithm {
+		t.Errorf("Error allowing an unsupported algorithm: %q", PS256)
+	} else if signer, err := NewSigner(TestXorAlg, key); err != nil {
+		t.Errorf("Error creating signer: %q", err)
+	} else if jws, err := signer.Sign(payload); err != nil {
+		t.Errorf("Error signing: %q", err)
+	} else if serialized, err = jws.CompactSerialize(); err != nil {
+		t.Fatalf("Error serializing: %q", err)
+	} else {
+		sigAsBytes, _ := base64URLDecode(string(jws.Signatures[0].Signature))
+		for i, v := range sigAsBytes {
+			if byte(v)^Key[i] != payload[i] {
+				t.Fatalf("Verification error at index %d. Got 0x%X expected 0x%X", i, byte(v), payload[i]^Key[i])
+			}
+		}
+
+		tokenParts := strings.Split(serialized, ".")
+		if len(tokenParts) != 3 {
+			t.Fatalf("Error: malformed token.  Expected 3 parts, got %d", len(tokenParts))
+		}
+		expectedAlgClaim := fmt.Sprintf(`"alg":"%s"`, TestXorAlg)
+		expectedKidClaim := fmt.Sprintf(`"kid":"%s"`, TestXorKeyId)
+		headerAsBytes, _ := base64URLDecode(string(tokenParts[0]))
+		header := string(headerAsBytes)
+		if !strings.Contains(header, expectedAlgClaim) {
+			t.Fatalf("Error: Expected algorithm claim %q but header was %q", expectedAlgClaim, header)
+		} else if !strings.Contains(header, expectedKidClaim) {
+			t.Fatalf("Error: Expected kid claim %q but header was %q", expectedKidClaim, header)
+		}
+
+	}
+}
+
+func TestVerifyWithAbstractVerifier(t *testing.T) {
+	// Pre create the compact serialized token if needed
+	if serialized == "" {
+		TesSignWithAbstractSigner(t)
+	}
+
+	key, _ := NewXorTestKey(Key)
+	wrongKey, _ := NewXorTestKey(WrongKey)
+	if jws, err := ParseSigned(serialized); err != nil {
+		t.Fatalf("Error parsing serialized JWT: %q", err)
+	} else if _, err := jws.Verify(key); err != nil {
+		t.Errorf("Error verifying: %q", err)
+	} else if _, err := jws.Verify(wrongKey); err == nil {
+		t.Error("Error tampered JWS passes verification")
+	}
+}
+
+const (
+	TestXorAlg   = SignatureAlgorithm("testXorAlg") // An unsupported algorithm simply used for test purposes
+	TestXorKeyId = "testXorKeyId"
+)
+
+// For the purposes of test and to provide an example of using an unsupported signing mechanism and key type this
+// signer/verifier uses a simple XOR of the first options.bytesToXor with the key
+type TestXorSignerVerifier struct {
+	key []byte
+}
+
+func (ctx *TestXorSignerVerifier) KeyID() string {
+	return TestXorKeyId
+}
+
+func (ctx *TestXorSignerVerifier) SignPayload(payload []byte, algorithm SignatureAlgorithm) (signature []byte, err error) {
+	if algorithm != TestXorAlg {
+		err = ErrUnsupportedAlgorithm
+	} else {
+		bytesToXor := len(ctx.key)
+		if bytesToXor > len(payload) {
+			bytesToXor = len(payload)
+		}
+
+		signature = make([]byte, bytesToXor)
+		for i, v := range payload[:bytesToXor] {
+			signature[i] = byte(v) ^ ctx.key[i]
+		}
+	}
+	return
+}
+
+func (ctx *TestXorSignerVerifier) Verify(payload []byte, signature []byte, algorithm SignatureAlgorithm) (err error) {
+	if algorithm != TestXorAlg {
+		err = ErrUnsupportedAlgorithm
+	} else {
+		for i, v := range signature {
+			if byte(v)^ctx.key[i] != payload[i] {
+				return errors.New("Verification error")
+			}
+		}
+	}
+	return
+}
+
+func NewXorTestKey(key []byte) (signerVerifier *TestXorSignerVerifier, err error) {
+	return &TestXorSignerVerifier{
+		key: key,
+	}, nil
+}

--- a/abstract_key_test.go
+++ b/abstract_key_test.go
@@ -32,7 +32,7 @@ var WrongKey = []byte{0x06, 0x07, 0x08}
 
 var serialized string
 
-func TesSignWithAbstractSigner(t *testing.T) {
+func TestSignWithAbstractSigner(t *testing.T) {
 	payload := []byte(JwsPayload)
 	key, _ := NewXorTestKey(Key)
 	if signer, err := NewSigner(PS256, key); err != nil {
@@ -73,7 +73,7 @@ func TesSignWithAbstractSigner(t *testing.T) {
 func TestVerifyWithAbstractVerifier(t *testing.T) {
 	// Pre create the compact serialized token if needed
 	if serialized == "" {
-		TesSignWithAbstractSigner(t)
+		TestSignWithAbstractSigner(t)
 	}
 
 	key, _ := NewXorTestKey(Key)

--- a/signing.go
+++ b/signing.go
@@ -103,6 +103,9 @@ func newVerifier(verificationKey interface{}) (payloadVerifier, error) {
 	case *JsonWebKey:
 		return newVerifier(verificationKey.Key)
 	default:
+		if av, ok := verificationKey.(AbstractVerifier); ok {
+			return newAbstractVerifier(av)
+		}
 		return nil, ErrUnsupportedKeyType
 	}
 }
@@ -133,6 +136,9 @@ func makeJWSRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipient
 		recipient.keyID = signingKey.KeyID
 		return recipient, nil
 	default:
+		if as, ok := signingKey.(AbstractSigner); ok {
+			return newAbstractSigner(as.(AbstractSigner), alg)
+		}
 		return recipientSigInfo{}, ErrUnsupportedKeyType
 	}
 }

--- a/signing.go
+++ b/signing.go
@@ -137,7 +137,7 @@ func makeJWSRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipient
 		return recipient, nil
 	default:
 		if as, ok := signingKey.(AbstractSigner); ok {
-			return newAbstractSigner(as.(AbstractSigner), alg)
+			return newAbstractSigner(as, alg)
 		}
 		return recipientSigInfo{}, ErrUnsupportedKeyType
 	}

--- a/signing.go
+++ b/signing.go
@@ -21,6 +21,8 @@ import (
 	"crypto/rsa"
 	"errors"
 	"fmt"
+	"crypto"
+	"io"
 )
 
 // NonceSource represents a source of random nonces to go into JWS objects
@@ -133,8 +135,70 @@ func makeJWSRecipient(alg SignatureAlgorithm, signingKey interface{}) (recipient
 		recipient.keyID = signingKey.KeyID
 		return recipient, nil
 	default:
+		if _, ok := signingKey.(GenericKey);ok{
+			return newGenericSigner(alg, signingKey.(GenericKey))
+		}
 		return recipientSigInfo{}, ErrUnsupportedKeyType
 	}
+}
+
+type SigningOptions uint
+
+const (
+	HashFunc SigningOptions = 1 + iota
+)
+
+type SignerOpts map[interface{}]interface{}
+
+func (opts SignerOpts) HashFunc () crypto.Hash {
+	if hf, ok := opts[HashFunc]; ok {
+		if hf, ok := hf.(crypto.Hash); ok {
+			return hf
+		}
+	}
+	return crypto.Hash(0)
+}
+
+type GenericKey interface {
+	RandReader() io.Reader
+	PublicKey() *JsonWebKey
+	SignPayload(rand io.Reader, digest []byte, opts SignerOpts) (signature []byte, err error)
+}
+
+type genericSigningKey struct{
+	genericKey GenericKey
+}
+
+func (key *genericSigningKey)signPayload(payload []byte, alg SignatureAlgorithm) (Signature, error) {
+	signature := Signature{protected:&rawHeader{}}
+	var err error
+	signingOpts := SignerOpts{}
+	switch alg {
+	case HS256, RS256, ES256, PS256:
+		signingOpts[HashFunc] = crypto.SHA256
+	case HS384, RS384, ES384, PS384:
+		signingOpts[HashFunc] = crypto.SHA384
+	case HS512, RS512, ES512, PS512:
+		signingOpts[HashFunc] = crypto.SHA512
+	default:
+		return signature, ErrUnsupportedAlgorithm
+	}
+	hasher := signingOpts.HashFunc().New()
+	if _, err = hasher.Write(payload); err != nil {
+		return signature, err
+	}
+	digest := hasher.Sum(nil)
+	if signature.Signature, err = key.genericKey.SignPayload(key.genericKey.RandReader(), digest, signingOpts); err != nil{
+		return signature, err
+	}
+	return signature, nil
+}
+func newGenericSigner(sigAlg SignatureAlgorithm, signingKey GenericKey) (recipientSigInfo, error) {
+	return recipientSigInfo{
+		sigAlg: sigAlg,
+		publicKey: signingKey.PublicKey(),
+		signer: &genericSigningKey{genericKey:signingKey},
+	}, nil
 }
 
 func (ctx *genericSigner) Sign(payload []byte) (*JsonWebSignature, error) {

--- a/signing_test.go
+++ b/signing_test.go
@@ -26,8 +26,6 @@ import (
 	"testing"
 
 	"github.com/square/go-jose/json"
-	"math/big"
-	"encoding/asn1"
 )
 
 type staticNonceSource string
@@ -451,60 +449,3 @@ func TestSignerWithJWKAndKeyID(t *testing.T) {
 		t.Errorf("expected message to have key id from JWK, but found '%s' instead", parsed2.Signatures[0].Header.KeyID)
 	}
 }
-
-type fakeGenericKey struct{
-	privateKey *ecdsa.PrivateKey
-}
-func (fgk fakeGenericKey)RandReader() io.Reader{
-	return rand.Reader
-}
-
-func (fgk fakeGenericKey)SignPayload(rand io.Reader, digest []byte, opts SignerOpts) (signature []byte, err error){
-
-	if sig, err := fgk.privateKey.Sign(fgk.RandReader(), digest, opts); err == nil{
-		return fmtEcdsaSig(sig)
-	}
-	return
-}
-
-func (fgk fakeGenericKey)PublicKey() *JsonWebKey{
-	return &JsonWebKey{Key: fgk.privateKey.Public()}
-}
-
-func fmtEcdsaSig(asn1Sig []byte) (rsSig []byte, err error){
-	type ecSig struct {
-		R, S *big.Int
-	}
-	unmarshalledSig := ecSig{}
-	if _, err := asn1.Unmarshal(asn1Sig, &unmarshalledSig);err != nil{
-		return nil, err
-	}
-	rsSig = append(unmarshalledSig.R.Bytes(), unmarshalledSig.S.Bytes()...)
-	return
-}
-
-func TestSignerWithGenericKey(t *testing.T) {
-	pvtKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	k(fakeGenericKey{privateKey: pvtKey})
-	if signer, err := NewSigner(ES256, fakeGenericKey{privateKey: pvtKey}); err != nil {
-		t.Errorf("error creating signer: %q", err)
-	} else if jws, err := signer.Sign([]byte("test")); err != nil {
-		t.Errorf("error signing: %q", err)
-	} else if compactSerialized, err := jws.CompactSerialize(); err != nil {
-		t.Errorf("error compact serializing: %q", err)
-	} else if jws, err := ParseSigned(compactSerialized); err != nil {
-		t.Errorf("error parsing token: %q", err)
-	} else if payload, err := jws.Verify(pvtKey.Public());err != nil {
-		t.Fatalf("Error Verifying token: %s", err)
-	} else {
-		println(string(payload))
-		println(compactSerialized)
-		println(string(jws.payload))
-		println(jws.FullSerialize())
-	}
-}
-
-func k(d GenericKey){
-	println(true)
-}
-


### PR DESCRIPTION
This is a solution to [issue 193](https://github.com/square/go-jose/issues/193) which outlines the motivation in much more detail than I'll do here.

This PR implements the notion of an AbstractSigner and AbstractVerifier. By implementing these 
interfaces a developer can extend the key types supported for signing beyond those native to Golang
and go-jose as well as implement support for unsupported algorithms and entropy sources other than
crypto/rand.Reader.

An example of how to implement such signers/verifiers is included in the test code.

**Question:**  Should I also include something like what I have in the test code doc_test.go?