### PR TITLE
Fix issue #206

### DIFF
--- a/symmetric.go
+++ b/symmetric.go
@@ -103,7 +103,7 @@ func newAESGCM(keySize int) contentCipher {
 func newAESCBC(keySize int) contentCipher {
 	return &aeadContentCipher{
 		keyBytes:     keySize * 2,
-		authtagBytes: 16,
+		authtagBytes: keySize,
 		getAead: func(key []byte) (cipher.AEAD, error) {
 			return josecipher.NewCBCHMAC(key, aes.NewCipher)
 		},


### PR DESCRIPTION
The auth tag len for AES-CBC+HMAC algorithms should match the key size, see RFC 7518 Section 5.2.4 and Section 5.2.5. Unfortunately this will (as-is) cause problems with decrypting AES-CBC+HMAC ciphertexts that were encrypted with this library that used 192-bit and 256-bit key sizes. Maybe we could address that with a special transitionary flag that allow for backwards compatibility? Or just note that data needs to be re-encrypted before upgrading in the release notes?