### PR TITLE
Add checks for octet length of X, Y, and D

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -353,6 +353,14 @@ func (key rawJSONWebKey) ecPublicKey() (*ecdsa.PublicKey, error) {
 		return nil, errors.New("square/go-jose: invalid EC key, missing x/y values")
 	}
 
+	if curveSize(curve) != len(key.X.data) {
+		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for x")
+	}
+
+	if curveSize(curve) != len(key.Y.data) {
+		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for y")
+	}
+
 	x := key.X.bigInt()
 	y := key.Y.bigInt()
 
@@ -517,6 +525,18 @@ func (key rawJSONWebKey) ecPrivateKey() (*ecdsa.PrivateKey, error) {
 
 	if key.X == nil || key.Y == nil || key.D == nil {
 		return nil, fmt.Errorf("square/go-jose: invalid EC private key, missing x/y/d values")
+	}
+
+	if curveSize(curve) != len(key.X.data) {
+		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for x")
+	}
+
+	if curveSize(curve) != len(key.Y.data) {
+		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for y")
+	}
+
+	if curveSize(curve) != len(key.D.data) {
+		return nil, fmt.Errorf("square/go-jose: invalid EC private key, wrong length for d")
 	}
 
 	x := key.X.bigInt()

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/hex"
 	"math/big"
 	"reflect"
+	"strings"
 	"testing"
 
 	"golang.org/x/crypto/ed25519"
@@ -220,7 +221,7 @@ func TestRoundtripEcPrivate(t *testing.T) {
 
 		ec2, err := jwk.ecPrivateKey()
 		if err != nil {
-			t.Error("problem converting ECDSA private -> JWK", i, err)
+			t.Errorf("problem converting ECDSA private -> JWK for %#v: %s", ecTestKey, err)
 		}
 
 		if !reflect.DeepEqual(ec2.Curve, ecTestKey.Curve) {
@@ -762,4 +763,107 @@ func TestJWKBufferSizeCheck(t *testing.T) {
 	// panic: square/go-jose: invalid call to newFixedSizeBuffer (len(data) > length)
 	// github.com/square/go-jose.newFixedSizeBuffer(0xc420014557, 0x41, 0x41, 0x20, 0x0)
 	jwk.Thumbprint(crypto.SHA256)
+}
+
+func TestJWKPaddingPrivateX(t *testing.T) {
+	key := `{
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "nPTIABcDASY6FNGSNfHCB51tY7qChtgzeVazOtLrwQ",
+    "y": "vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs",
+    "d": "nIVCvMR2wkLmeGJErOpI23VDHl2s3JwGdbzKy0odir0"
+  }`
+	var jwk JSONWebKey
+	err := jwk.UnmarshalJSON([]byte(key))
+	if err == nil {
+		t.Errorf("Expected key with short x to fail unmarshalling")
+	}
+	if !strings.Contains(err.Error(), "wrong length for x") {
+		t.Errorf("Wrong error for short x, got %q", err)
+	}
+	if jwk.Valid() {
+		t.Errorf("Expected key to be invalid, but it was valid.")
+	}
+}
+
+func TestJWKPaddingPrivateY(t *testing.T) {
+	key := `{
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs",
+    "y": "nPTIABcDASY6FNGSNfHCB51tY7qChtgzeVazOtLrwQ",
+    "d": "nIVCvMR2wkLmeGJErOpI23VDHl2s3JwGdbzKy0odir0"
+  }`
+	var jwk JSONWebKey
+	err := jwk.UnmarshalJSON([]byte(key))
+	if err == nil {
+		t.Errorf("Expected key with short x to fail unmarshalling")
+	}
+	if !strings.Contains(err.Error(), "wrong length for y") {
+		t.Errorf("Wrong error for short y, got %q", err)
+	}
+	if jwk.Valid() {
+		t.Errorf("Expected key to be invalid, but it was valid.")
+	}
+}
+
+func TestJWKPaddingPrivateD(t *testing.T) {
+	key := `{
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs",
+    "y": "qnPTIABcDASY6FNGSNfHCB51tY7qChtgzeVazOtLrwQ",
+    "d": "IVCvMR2wkLmeGJErOpI23VDHl2s3JwGdbzKy0odir0"
+  }`
+	var jwk JSONWebKey
+	err := jwk.UnmarshalJSON([]byte(key))
+	if err == nil {
+		t.Errorf("Expected key with short x to fail unmarshalling")
+	}
+	if !strings.Contains(err.Error(), "wrong length for d") {
+		t.Errorf("Wrong error for short d, got %q", err)
+	}
+	if jwk.Valid() {
+		t.Errorf("Expected key to be invalid, but it was valid.")
+	}
+}
+
+func TestJWKPaddingX(t *testing.T) {
+	key := `{
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "nPTIABcDASY6FNGSNfHCB51tY7qChtgzeVazOtLrwQ",
+    "y": "vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs"
+  }`
+	var jwk JSONWebKey
+	err := jwk.UnmarshalJSON([]byte(key))
+	if err == nil {
+		t.Errorf("Expected key with short x to fail unmarshalling")
+	}
+	if !strings.Contains(err.Error(), "wrong length for x") {
+		t.Errorf("Wrong error for short x, got %q", err)
+	}
+	if jwk.Valid() {
+		t.Errorf("Expected key to be invalid, but it was valid.")
+	}
+}
+
+func TestJWKPaddingY(t *testing.T) {
+	key := `{
+    "kty": "EC",
+    "crv": "P-256",
+    "x": "vEEs4V0egJkNyM2Q4pp001zu14VcpQ0_Ei8xOOPxKZs",
+    "y": "nPTIABcDASY6FNGSNfHCB51tY7qChtgzeVazOtLrwQ"
+  }`
+	var jwk JSONWebKey
+	err := jwk.UnmarshalJSON([]byte(key))
+	if err == nil {
+		t.Errorf("Expected key with short y to fail unmarshalling")
+	}
+	if !strings.Contains(err.Error(), "wrong length for y") {
+		t.Errorf("Wrong error for short y, got %q", err)
+	}
+	if jwk.Valid() {
+		t.Errorf("Expected key to be invalid, but it was valid.")
+	}
 }

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -221,7 +221,7 @@ func TestRoundtripEcPrivate(t *testing.T) {
 
 		ec2, err := jwk.ecPrivateKey()
 		if err != nil {
-			t.Errorf("problem converting ECDSA private -> JWK for %#v: %s", ecTestKey, err)
+			t.Fatalf("problem converting ECDSA private -> JWK for %#v: %s", ecTestKey, err)
 		}
 
 		if !reflect.DeepEqual(ec2.Curve, ecTestKey.Curve) {
@@ -255,7 +255,7 @@ func TestRoundtripX5C(t *testing.T) {
 	var jwk2 JSONWebKey
 	err = jwk2.UnmarshalJSON(jsonbar)
 	if err != nil {
-		t.Error("problem unmarshalling", err)
+		t.Fatal("problem unmarshalling", err)
 	}
 
 	if !reflect.DeepEqual(testCertificates, jwk2.Certificates) {
@@ -289,12 +289,12 @@ func TestMarshalUnmarshal(t *testing.T) {
 			var jwk2 JSONWebKey
 			err = jwk2.UnmarshalJSON(jsonbar)
 			if err != nil {
-				t.Error("problem unmarshalling", i, err)
+				t.Fatal("problem unmarshalling", i, err)
 			}
 
 			jsonbar2, err := jwk2.MarshalJSON()
 			if err != nil {
-				t.Error("problem marshaling", i, err)
+				t.Fatal("problem marshaling", i, err)
 			}
 
 			if !bytes.Equal(jsonbar, jsonbar2) {
@@ -594,11 +594,11 @@ func TestMarshalUnmarshalJWKSet(t *testing.T) {
 	var set2 JSONWebKeySet
 	err = json.Unmarshal(jsonbar, &set2)
 	if err != nil {
-		t.Error("problem unmarshalling set", err)
+		t.Fatal("problem unmarshalling set", err)
 	}
 	jsonbar2, err := json.Marshal(&set2)
 	if err != nil {
-		t.Error("problem marshalling set", err)
+		t.Fatal("problem marshalling set", err)
 	}
 	if !bytes.Equal(jsonbar, jsonbar2) {
 		t.Error("roundtrip should not lose information")


### PR DESCRIPTION
The JWK spec says these fields in EC keys MUST be a fixed length, but go-jose wasn't
checking their length on input. I got a report from the Let's Encrypt forums that this
caused some confusion with certain software that was generating invalid JWKs. Boulder
(using go-jose) ingested those keys just fine, but output a different (valid) encoding.

This change enforces the correct length on parsing. It also changes some `t.Errorf` to
`t.Fatalf` that I noticed during testing. The `t.Fatalf` checks are for failures that prevent
the test from meaningfully continuing.