### PR TITLE
Fix Expiry.Time() to return zero-value of time.Time{} when n is 0

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -73,6 +73,11 @@ func (n *NumericDate) UnmarshalJSON(b []byte) error {
 
 // Time returns time.Time representation of NumericDate.
 func (n NumericDate) Time() time.Time {
+	if n == NumericDate(0) {
+		// time.Unix(0,0) != time.Time{} (it should, but it doesn't).
+		// This is a workaround.
+		return time.Time{}
+	}
 	return time.Unix(int64(n), 0)
 }
 

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -78,3 +78,12 @@ func TestDecodeClaims(t *testing.T) {
 		assert.Equal(t, v.Err, json.Unmarshal([]byte(v.Raw), &c))
 	}
 }
+
+func TestTime(t *testing.T) {
+	zeroDate := NumericDate(0)
+	assert.True(t, time.Time{}.Equal(zeroDate.Time()), "Expected derived time to be time.Time{}")
+
+	nonZeroDate := NumericDate(1547232324)
+	expected := time.Date(2019, 1, 11, 18, 45, 24, 0, time.UTC)
+	assert.Truef(t, expected.Equal(nonZeroDate.Time()), "Expected derived time to be %s", expected)
+}


### PR DESCRIPTION
time.Unix(0, 0) does not return time.Time{} as one might expect. Admittedly, this is a work around for what I'd perceive as a bug in golang.

For reference, this is required for validating JWT expiration only where the expiry is set. E.g.:
```
if !claims.Expiry.Time().IsZero() && claims.Expiry.Time().Before(time.Now()) {
     return errors.New("Expired token")
}
```

Please let me know if there's a more preferable way to accomplish this check.

See https://play.golang.org/p/sM4SZKzWvFw