### PR TITLE
jwt.ValidateWithLeeway: Return error if IssuedAt (iat) is in the future

### DIFF
--- a/jwt/errors.go
+++ b/jwt/errors.go
@@ -46,5 +46,8 @@ var ErrNotValidYet = errors.New("square/go-jose/jwt: validation failed, token no
 // ErrExpired indicates that token is used after expiry time indicated in exp claim.
 var ErrExpired = errors.New("square/go-jose/jwt: validation failed, token is expired (exp)")
 
-// ErrInvalidContentType indicated that token requires JWT cty header.
+// ErrIssuedInTheFuture indicates that the iat field is in the future.
+var ErrIssuedInTheFuture = errors.New("square/go-jsoe/jwt: validation field, token issued in the future (iat)")
+
+// ErrInvalidContentType indicates that token requires JWT cty header.
 var ErrInvalidContentType = errors.New("square/go-jose/jwt: expected content type to be JWT (cty header)")

--- a/jwt/validation.go
+++ b/jwt/validation.go
@@ -102,5 +102,11 @@ func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
 		return ErrExpired
 	}
 
+	// IssuedAt is optional but cannot be in the future. This is not required by the RFC, but
+	// something is misconfigured if this happens and we should not trust it.
+	if !e.Time.IsZero() && e.Time.Add(leeway).Before(c.IssuedAt.Time()) {
+		return ErrIssuedInTheFuture
+	}
+
 	return nil
 }


### PR DESCRIPTION
Add a check to ValidateWithLeeway that the IssuedAt (iat) field is in the
past. This field is optional, and this check is not required by the RFC,
but seems like a reasonable check. See:
https://tools.ietf.org/html/rfc7519#section-4.1.6

Fixes https://github.com/square/go-jose/issues/216