### PR TITLE
Reverse bytes in Ed25519 keys.

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -230,7 +230,7 @@ func (k *JSONWebKey) Thumbprint(hash crypto.Hash) ([]byte, error) {
 	case *rsa.PrivateKey:
 		input, err = rsaThumbprintInput(key.N, key.E)
 	case ed25519.PrivateKey:
-		input, err = edThumbprintInput(ed25519.PublicKey(key[0:32]))
+		input, err = edThumbprintInput(ed25519.PublicKey(key[32:]))
 	default:
 		return nil, fmt.Errorf("square/go-jose: unknown key type '%s'", reflect.TypeOf(key))
 	}
@@ -421,8 +421,8 @@ func (key rawJSONWebKey) edPrivateKey() (ed25519.PrivateKey, error) {
 	}
 
 	privateKey := make([]byte, ed25519.PrivateKeySize)
-	copy(privateKey[0:32], key.X.bytes())
-	copy(privateKey[32:], key.D.bytes())
+	copy(privateKey[0:32], key.D.bytes())
+	copy(privateKey[32:], key.X.bytes())
 	rv := ed25519.PrivateKey(privateKey)
 	return rv, nil
 }
@@ -483,9 +483,9 @@ func (key rawJSONWebKey) rsaPrivateKey() (*rsa.PrivateKey, error) {
 }
 
 func fromEdPrivateKey(ed ed25519.PrivateKey) (*rawJSONWebKey, error) {
-	raw := fromEdPublicKey(ed25519.PublicKey(ed[0:32]))
+	raw := fromEdPublicKey(ed25519.PublicKey(ed[32:]))
 
-	raw.D = newBuffer(ed[32:])
+	raw.D = newBuffer(ed[0:32])
 	return raw, nil
 }
 

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -440,9 +440,9 @@ var cookbookJWKs = []string{
 	//ED Private
 	stripWhitespace(`{
      "kty": "OKP",
-     "crv": "Ed25519",
-     "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A",
-     "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo"
+		 "crv": "Ed25519",
+		 "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+     "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A"
    }`),
 
 	// EC Private

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -440,8 +440,8 @@ var cookbookJWKs = []string{
 	//ED Private
 	stripWhitespace(`{
      "kty": "OKP",
-		 "crv": "Ed25519",
-		 "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
+     "crv": "Ed25519",
+     "x": "11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo",
      "d": "nWGxne_9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A"
    }`),
 


### PR DESCRIPTION
Golang golang.org/x/crypto/ed25519 package uses 64 bytes to store
the public and private parts of the key, the first 32 bytes correspond
to the private part and the last 32 to the public part. See:
https://github.com/golang/crypto/blob/master/ed25519/ed25519.go#L90

go-jose implementation reverses the bytes causing that the JSON version
of the private key has the private part in the 'x' property and the
public in the 'd', and it should be the other way around, see:
https://tools.ietf.org/html/rfc8037#appendix-A.1