### PR TITLE
If KeyId is empty, do not include it in the header

### DIFF
--- a/signing.go
+++ b/signing.go
@@ -233,7 +233,10 @@ func (ctx *genericSigner) Sign(payload []byte) (*JSONWebSignature, error) {
 			if ctx.embedJWK {
 				protected[headerJWK] = recipient.publicKey()
 			} else {
-				protected[headerKeyID] = recipient.publicKey().KeyID
+				keyID := recipient.publicKey().KeyID
+				if keyID != "" {
+					protected[headerKeyID] = keyID
+				}
 			}
 		}
 


### PR DESCRIPTION
The current implementation can end up with an empty `kid` field in the JWT header:

```
{
  "alg": "RS256",
  "kid": ""
}
```

In other places, `kid` is treated as an `,omitempty` when using `encoding/json` struct tags, but in this code path we are building up the map ourselves, and therefore we need to check if `.KeyID` is empty directly.
