### PR TITLE
use rsa.PSSSaltLengthEqualsHash to match rfc

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -29,7 +29,7 @@ import (
 	"math/big"
 
 	"golang.org/x/crypto/ed25519"
-	"gopkg.in/square/go-jose.v2/cipher"
+	josecipher "gopkg.in/square/go-jose.v2/cipher"
 	"gopkg.in/square/go-jose.v2/json"
 )
 
@@ -288,7 +288,7 @@ func (ctx rsaDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm
 		out, err = rsa.SignPKCS1v15(RandReader, ctx.privateKey, hash, hashed)
 	case PS256, PS384, PS512:
 		out, err = rsa.SignPSS(RandReader, ctx.privateKey, hash, hashed, &rsa.PSSOptions{
-			SaltLength: rsa.PSSSaltLengthAuto,
+			SaltLength: rsa.PSSSaltLengthEqualsHash,
 		})
 	}
 


### PR DESCRIPTION
Based on RFC 3447, and other discussions around RSAPSS: the salt length should match the size of the algorithm used for signing the token.

This change will cause existing implementations of the go-jose library to generate new tokens with a salt length matching the chosen hash library, but still allow it to detect the hash size in existing tokens.

Here is a link to another go library with a similar library: https://github.com/dgrijalva/jwt-go/issues/285

Here is a reference to another go library
See a python implementation for a similar example: https://github.com/jpadilla/pyjwt/blob/d25c92ca5e9980ca7bc8b31420bf36e3f4a9e3f0/jwt/algorithms.py#L385