### PR TITLE
Support x5u, x5t, and x5t#S256 headers (for JWK)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/square/go-jose
 
 go 1.12
 
-require golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
+require (
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f h1:R423Cnkcp5JABoeemiGEPlt9tHXFfw5kvc0yqlxRPWo=
 golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=

--- a/jwk.go
+++ b/jwk.go
@@ -17,15 +17,19 @@
 package jose
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"math/big"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -57,16 +61,31 @@ type rawJSONWebKey struct {
 	Dq *byteBuffer `json:"dq,omitempty"`
 	Qi *byteBuffer `json:"qi,omitempty"`
 	// Certificates
-	X5c []string `json:"x5c,omitempty"`
+	X5c       []string    `json:"x5c,omitempty"`
+	X5u       *url.URL    `json:"x5u,omitempty"`
+	X5tSHA1   *byteBuffer `json:"x5t,omitempty"`
+	X5tSHA256 *byteBuffer `json:"x5t#S256,omitempty"`
 }
 
 // JSONWebKey represents a public or private key in JWK format.
 type JSONWebKey struct {
-	Key          interface{}
+	// Cryptographic key, can be a symmetric or asymmetric key.
+	Key interface{}
+	// Key identifier, parsed from `kid` header.
+	KeyID string
+	// Key algorithm, parsed from `alg` header.
+	Algorithm string
+	// Key use, parsed from `use` header.
+	Use string
+
+	// X.509 certificate chain, parsed from `x5c` header.
 	Certificates []*x509.Certificate
-	KeyID        string
-	Algorithm    string
-	Use          string
+	// X.509 certificate URL, parsed from `x5u` header.
+	CertificatesURL *url.URL
+	// X.509 certificate thumbprint (SHA-1), parsed from `x5t` header.
+	CertificateThumbprintSHA1 []byte
+	// X.509 certificate thumbprint (SHA-256), parsed from `x5t#S256` header.
+	CertificateThumbprintSHA256 []byte
 }
 
 // MarshalJSON serializes the given key to its JSON representation.
@@ -105,6 +124,36 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 		raw.X5c = append(raw.X5c, base64.StdEncoding.EncodeToString(cert.Raw))
 	}
 
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 {
+		if x5tSHA1Len != sha1.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-1 thumbprint (must be %d bytes, not %d)", sha1.Size, x5tSHA1Len)
+		}
+		raw.X5tSHA1 = newFixedSizeBuffer(k.CertificateThumbprintSHA1, sha1.Size)
+	}
+	if x5tSHA256Len > 0 {
+		if x5tSHA256Len != sha256.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-256 thumbprint (must be %d bytes, not %d)", sha256.Size, x5tSHA256Len)
+		}
+		raw.X5tSHA256 = newFixedSizeBuffer(k.CertificateThumbprintSHA256, sha256.Size)
+	}
+
+	// If cert chain is attached (as opposed to being behind a URL), check the
+	// keys thumbprints to make sure they match what is expected. This is to
+	// ensure we don't accidentally produce a JWK with semantically inconsistent
+	// data in the headers.
+	if len(k.Certificates) > 0 {
+		expectedSHA1 := sha1.Sum(k.Certificates[0].Raw)
+		expectedSHA256 := sha256.Sum256(k.Certificates[0].Raw)
+		if !bytes.Equal(k.CertificateThumbprintSHA1, expectedSHA1[:]) ||
+			!bytes.Equal(k.CertificateThumbprintSHA256, expectedSHA256[:]) {
+			return nil, errors.New("square/go-jose: invalid SHA-1 or SHA-256 thumbprint, does not match cert chain")
+		}
+	}
+
+	raw.X5u = k.CertificatesURL
+
 	return json.Marshal(raw)
 }
 
@@ -116,28 +165,61 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		return err
 	}
 
+	certs, err := parseCertificateChain(raw.X5c)
+	if err != nil {
+		return fmt.Errorf("square/go-jose: failed to unmarshal x5c field: %s", err)
+	}
+
 	var key interface{}
+	var certPub interface{}
+	var keyPub interface{}
+
+	if len(certs) > 0 {
+		// We need to check that leaf public key matches the key embedded in this
+		// JWK, as required by the standard (see RFC 7517, Section 4.7). Otherwise
+		// the JWK parsed could be semantically invalid. Technically, should also
+		// check key usage fields and other extensions on the cert here, but the
+		// standard doesn't exactly explain how they're supposed to map from the
+		// JWK representation to the X.509 extensions.
+		certPub = certs[0].PublicKey
+	}
+
 	switch raw.Kty {
 	case "EC":
 		if raw.D != nil {
 			key, err = raw.ecPrivateKey()
+			if err == nil {
+				keyPub = key.(*ecdsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.ecPublicKey()
+			keyPub = key
 		}
 	case "RSA":
 		if raw.D != nil {
 			key, err = raw.rsaPrivateKey()
+			if err == nil {
+				keyPub = key.(*rsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.rsaPublicKey()
+			keyPub = key
 		}
 	case "oct":
+		if certPub != nil {
+			return errors.New("square/go-jose: invalid JWK, found 'oct' (symmetric) key with cert chain")
+		}
 		key, err = raw.symmetricKey()
 	case "OKP":
 		if raw.Crv == "Ed25519" && raw.X != nil {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
+				if err == nil {
+					keyPub = key.(ed25519.PrivateKey).Public()
+				}
 			} else {
 				key, err = raw.edPublicKey()
+				keyPub = key
 			}
 		} else {
 			err = fmt.Errorf("square/go-jose: unknown curve %s'", raw.Crv)
@@ -146,12 +228,43 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		err = fmt.Errorf("square/go-jose: unknown json web key type '%s'", raw.Kty)
 	}
 
-	if err == nil {
-		*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use}
+	if err != nil {
+		return
+	}
 
-		k.Certificates, err = parseCertificateChain(raw.X5c)
-		if err != nil {
-			return fmt.Errorf("failed to unmarshal x5c field: %s", err)
+	if certPub != nil && keyPub != nil {
+		if !reflect.DeepEqual(certPub, keyPub) {
+			return errors.New("square/go-jose: invalid JWK, public keys in key and x5c fields to not match")
+		}
+	}
+
+	*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use, Certificates: certs}
+
+	k.CertificatesURL = raw.X5u
+	k.CertificateThumbprintSHA1 = raw.X5tSHA1.bytes()
+	k.CertificateThumbprintSHA256 = raw.X5tSHA256.bytes()
+
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 && x5tSHA1Len != sha1.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t header is of incorrect size")
+	}
+	if x5tSHA256Len > 0 && x5tSHA256Len != sha256.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t header is of incorrect size")
+	}
+
+	// If certificate chain *and* thumbprints are set, verify correctness.
+	if len(k.Certificates) > 0 {
+		leaf := k.Certificates[0]
+		sha1sum := sha1.Sum(leaf.Raw)
+		sha256sum := sha256.Sum256(leaf.Raw)
+
+		if len(k.CertificateThumbprintSHA1) > 0 && !bytes.Equal(sha1sum[:], k.CertificateThumbprintSHA1) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t value")
+		}
+
+		if len(k.CertificateThumbprintSHA256) > 0 && !bytes.Equal(sha256sum[:], k.CertificateThumbprintSHA256) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t#S256 value")
 		}
 	}
 

--- a/jws_test.go
+++ b/jws_test.go
@@ -214,7 +214,7 @@ func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 
 	jws, err := ParseSigned(input)
 	if err != nil {
-		t.Error("Unable to parse valid message.")
+		t.Fatal("Unable to parse valid message", err)
 	}
 	if len(jws.Signatures) != 1 {
 		t.Error("Too many or too few signatures.")


### PR DESCRIPTION
Changes:
* Support x5u, x5t, and x5t#S256 headers.
* Check that cert pub key matches JWK pub key on unmarshal.
* Check that thumbprints match X.509 leaf cert on marshal/unmarshal.
* Add additional tests for invalid thumbprints, cert/key mismatch.

Note that we _could_ do additional checks on the cert chain, like compare the key usage extension to the defined "use" in the JWK header. But I decided not to implement that at this time -- the standard is a bit fuzzy about how to match these (sigh). We also don't check the cert chain that the x5u URI points at, because we don't want to do an HTTP get on a JSON unmarshal and it could change at any time regardless.

cc @0x13a 