### PR TITLE
Allow single string audience

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -110,6 +110,16 @@ func (s *Audience) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalJSON converts audience to json representation.
+func (s Audience) MarshalJSON() ([]byte, error) {
+	type Alias Audience
+	if len(s) == 1 {
+		return json.Marshal(s[0])
+	}
+	return json.Marshal((Alias)(s))
+}
+
+//Contains checks whether a given string is included in the Audience
 func (s Audience) Contains(v string) bool {
 	for _, a := range s {
 		if a == v {

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -45,6 +45,25 @@ func TestEncodeClaims(t *testing.T) {
 	assert.Equal(t, expected, string(b))
 }
 
+func TestEncodeClaimsWithSingleAudience(t *testing.T) {
+	now := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	c := Claims{
+		Issuer:    "issuer",
+		Subject:   "subject",
+		Audience:  Audience{"a1"},
+		NotBefore: NewNumericDate(time.Time{}),
+		IssuedAt:  NewNumericDate(now),
+		Expiry:    NewNumericDate(now.Add(1 * time.Hour)),
+	}
+
+	b, err := json.Marshal(c)
+	assert.NoError(t, err)
+
+	expected := `{"iss":"issuer","sub":"subject","aud":"a1","exp":1451610000,"iat":1451606400}`
+	assert.Equal(t, expected, string(b))
+}
+
 func TestDecodeClaims(t *testing.T) {
 	s := []byte(`{"iss":"issuer","sub":"subject","aud":["a1","a2"],"exp":1451610000,"iat":1451606400}`)
 	now := time.Date(2016, 1, 1, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
When trying to use this library to authenticate with [box](https://developer.box.com/docs/construct-jwt-claim-manually) I get an error stating "Please check the 'aud' claim. Should be a string".

This appears to be because the 'aud' is sent as an array rather than a string (I do think that the box api should be able to handle an array of length 1, so I've raised an issue with them as well).

According to the [spec](https://tools.ietf.org/html/rfc7519#section-4.1.3), "In the special case when the JWT has one audience, the "aud" value MAY be a single case-sensitive string containing a StringOrURI value."

The wording on this isn't super clear, and I'm inexperienced in both Go and JWT, but the way I read the above makes me think it's safe to always just send a string, rather than array, when there is only one Audience. That's what this pull request does.