### PR TITLE
Expose payload verifier in interface

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -303,7 +303,7 @@ func (ctx rsaDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm
 }
 
 // Verify the given payload
-func (ctx rsaEncrypterVerifier) verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
+func (ctx rsaEncrypterVerifier) VerifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
 	var hash crypto.Hash
 
 	switch alg {
@@ -483,7 +483,7 @@ func (ctx edDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm)
 	}, nil
 }
 
-func (ctx edEncrypterVerifier) verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
+func (ctx edEncrypterVerifier) VerifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
 	if alg != EdDSA {
 		return ErrUnsupportedAlgorithm
 	}
@@ -552,7 +552,7 @@ func (ctx ecDecrypterSigner) signPayload(payload []byte, alg SignatureAlgorithm)
 }
 
 // Verify the given payload
-func (ctx ecEncrypterVerifier) verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
+func (ctx ecEncrypterVerifier) VerifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
 	var keySize int
 	var hash crypto.Hash
 

--- a/asymmetric_test.go
+++ b/asymmetric_test.go
@@ -34,7 +34,7 @@ func TestEd25519(t *testing.T) {
 
 	enc := new(edEncrypterVerifier)
 	enc.publicKey = ed25519PublicKey
-	err = enc.verifyPayload([]byte{}, []byte{}, "XYZ")
+	err = enc.VerifyPayload([]byte{}, []byte{}, "XYZ")
 	if err != ErrUnsupportedAlgorithm {
 		t.Error("should return error on invalid algorithm")
 	}
@@ -53,12 +53,12 @@ func TestEd25519(t *testing.T) {
 	if sig.Signature == nil {
 		t.Error("Check the signature")
 	}
-	err = enc.verifyPayload([]byte("This is a test"), sig.Signature, "EdDSA")
+	err = enc.VerifyPayload([]byte("This is a test"), sig.Signature, "EdDSA")
 	if err != nil {
 		t.Error("should not error trying to verify payload")
 	}
 
-	err = enc.verifyPayload([]byte("This is test number 2"), sig.Signature, "EdDSA")
+	err = enc.VerifyPayload([]byte("This is test number 2"), sig.Signature, "EdDSA")
 	if err == nil {
 		t.Error("should not error trying to verify payload")
 	}
@@ -82,7 +82,7 @@ func TestInvalidAlgorithmsRSA(t *testing.T) {
 		t.Error("should return error on invalid algorithm")
 	}
 
-	err = enc.verifyPayload([]byte{}, []byte{}, "XYZ")
+	err = enc.VerifyPayload([]byte{}, []byte{}, "XYZ")
 	if err != ErrUnsupportedAlgorithm {
 		t.Error("should return error on invalid algorithm")
 	}
@@ -387,7 +387,7 @@ func TestInvalidECPublicKey(t *testing.T) {
 }
 
 func TestInvalidAlgorithmEC(t *testing.T) {
-	err := ecEncrypterVerifier{publicKey: &ecTestKey256.PublicKey}.verifyPayload([]byte{}, []byte{}, "XYZ")
+	err := ecEncrypterVerifier{publicKey: &ecTestKey256.PublicKey}.VerifyPayload([]byte{}, []byte{}, "XYZ")
 	if err != ErrUnsupportedAlgorithm {
 		t.Fatal("should not accept invalid/unsupported algorithm")
 	}

--- a/crypter.go
+++ b/crypter.go
@@ -152,7 +152,7 @@ func NewEncrypter(enc ContentEncryption, rcpt Recipient, opts *EncrypterOptions)
 			return nil, ErrUnsupportedKeyType
 		}
 		if encrypter.cipher.keySize() != len(rawKey.([]byte)) {
-			return nil, ErrInvalidKeySize
+			return nil, ErrInvalidKey
 		}
 		encrypter.keyGenerator = staticKeyGenerator{
 			key: rawKey.([]byte),

--- a/crypter_test.go
+++ b/crypter_test.go
@@ -639,13 +639,13 @@ func TestDirectEncryptionKeySizeCheck(t *testing.T) {
 
 	// AES-128 with 32-byte key should reject
 	_, err := NewEncrypter(A128GCM, Recipient{Algorithm: DIRECT, Key: key32}, nil)
-	if err != ErrInvalidKeySize {
+	if err != ErrInvalidKey {
 		t.Error("Should reject AES-128 with 32-byte key")
 	}
 
 	// AES-256 with 16-byte key should reject
 	_, err = NewEncrypter(A256GCM, Recipient{Algorithm: DIRECT, Key: key16}, nil)
-	if err != ErrInvalidKeySize {
+	if err != ErrInvalidKey {
 		t.Error("Should reject AES-256 with 16-byte key")
 	}
 }

--- a/doc_test.go
+++ b/doc_test.go
@@ -111,7 +111,12 @@ func Example_jWS() {
 	// Now we can verify the signature on the payload. An error here would
 	// indicate the the message failed to verify, e.g. because the signature was
 	// broken or the message was tampered with.
-	output, err := object.Verify(&privateKey.PublicKey)
+	verifier, err := NewRSAVerifier(&privateKey.PublicKey)
+	if err != nil {
+		panic(err)
+	}
+
+	output, err := object.Verify(verifier)
 	if err != nil {
 		panic(err)
 	}

--- a/opaque.go
+++ b/opaque.go
@@ -66,18 +66,3 @@ func (o *opaqueSigner) signPayload(payload []byte, alg SignatureAlgorithm) (Sign
 		protected: &rawHeader{},
 	}, nil
 }
-
-// OpaqueVerifier is an interface that supports verifying payloads with opaque
-// public key(s). An OpaqueSigner may rotate signing keys transparently to the
-// user of this interface.
-type OpaqueVerifier interface {
-	VerifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error
-}
-
-type opaqueVerifier struct {
-	verifier OpaqueVerifier
-}
-
-func (o *opaqueVerifier) verifyPayload(payload []byte, signature []byte, alg SignatureAlgorithm) error {
-	return o.verifier.VerifyPayload(payload, signature, alg)
-}

--- a/shared.go
+++ b/shared.go
@@ -58,10 +58,10 @@ var (
 	// an RSA private key with more than two primes.
 	ErrUnsupportedKeyType = errors.New("square/go-jose: unsupported key type/format")
 
-	// ErrInvalidKeySize indicates that the given key is not the correct size
-	// for the selected algorithm. This can occur, for example, when trying to
+	// ErrInvalidKey indicates that the given key is not valid (e.g. not the correct
+	// size) for the selected algorithm. This can occur, for example, when trying to
 	// encrypt with AES-256 but passing only a 128-bit key as input.
-	ErrInvalidKeySize = errors.New("square/go-jose: invalid key size for algorithm")
+	ErrInvalidKey = errors.New("square/go-jose: invalid key for algorithm")
 
 	// ErrNotSupported serialization of object is not supported. This occurs when
 	// trying to compact-serialize an object which can't be represented in

--- a/symmetric.go
+++ b/symmetric.go
@@ -454,7 +454,7 @@ func (ctx symmetricMac) signPayload(payload []byte, alg SignatureAlgorithm) (Sig
 }
 
 // Verify the given payload
-func (ctx symmetricMac) verifyPayload(payload []byte, mac []byte, alg SignatureAlgorithm) error {
+func (ctx symmetricMac) VerifyPayload(payload []byte, mac []byte, alg SignatureAlgorithm) error {
 	expected, err := ctx.hmac(payload, alg)
 	if err != nil {
 		return errors.New("square/go-jose: failed to compute hmac")


### PR DESCRIPTION
Makes the previously private payloadVerifier interface public as just a Verifier, and merges it with OpaqueVerifier. Adds type-safe functions for instantiating new verifiers from RSA, ECDSA, etc. keys so we can avoid some of the reflection we used to do internally. Should also make the interface friendlier to consumers of the library.