### PR TITLE
Update import paths for upcoming V3 release

### DIFF
--- a/asymmetric.go
+++ b/asymmetric.go
@@ -28,8 +28,8 @@ import (
 	"fmt"
 	"math/big"
 
-	josecipher "github.com/square/go-jose/cipher"
-	"github.com/square/go-jose/json"
+	josecipher "github.com/square/go-jose/v3/cipher"
+	"github.com/square/go-jose/v3/json"
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/crypter.go
+++ b/crypter.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // Encrypter represents an encrypter which produces an encrypted JWE object.

--- a/cryptosigner/cryptosigner.go
+++ b/cryptosigner/cryptosigner.go
@@ -28,7 +28,7 @@ import (
 	"io"
 	"math/big"
 
-	"github.com/square/go-jose"
+	"github.com/square/go-jose/v3"
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/cryptosigner/cryptosigner_test.go
+++ b/cryptosigner/cryptosigner_test.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/square/go-jose"
+	"github.com/square/go-jose/v3"
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/encoding.go
+++ b/encoding.go
@@ -25,7 +25,7 @@ import (
 	"math/big"
 	"regexp"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 var stripWhitespaceRegex = regexp.MustCompile(`\s`)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/square/go-jose
+module github.com/square/go-jose/v3
 
 go 1.12
 

--- a/jose-util/crypto.go
+++ b/jose-util/crypto.go
@@ -16,7 +16,7 @@
 
 package main
 
-import jose "github.com/square/go-jose"
+import jose "github.com/square/go-jose/v3"
 
 func encrypt() {
 	pub, err := LoadPublicKey(keyBytes())

--- a/jose-util/format.go
+++ b/jose-util/format.go
@@ -16,7 +16,7 @@
 
 package main
 
-import jose "github.com/square/go-jose"
+import jose "github.com/square/go-jose/v3"
 
 func expand() {
 	input := string(readInput(*inFile))

--- a/jose-util/generate.go
+++ b/jose-util/generate.go
@@ -26,7 +26,7 @@ import (
 	"fmt"
 
 	"github.com/google/uuid"
-	jose "github.com/square/go-jose"
+	jose "github.com/square/go-jose/v3"
 	"golang.org/x/crypto/ed25519"
 )
 

--- a/jose-util/go.mod
+++ b/jose-util/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/google/uuid v1.1.1
-	github.com/square/go-jose v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"os"
 
-	jose "github.com/square/go-jose"
+	jose "github.com/square/go-jose/v3"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/jose-util/utils.go
+++ b/jose-util/utils.go
@@ -21,7 +21,7 @@ import (
 	"encoding/pem"
 	"errors"
 
-	jose "github.com/square/go-jose"
+	jose "github.com/square/go-jose/v3"
 )
 
 func LoadJSONWebKey(json []byte, pub bool) (*jose.JSONWebKey, error) {

--- a/jwe.go
+++ b/jwe.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // rawJSONWebEncryption represents a raw JWE JSON object. Used for parsing/serializing.

--- a/jwk.go
+++ b/jwk.go
@@ -35,7 +35,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // rawJSONWebKey represents a public or private key in JWK format, used for parsing/serializing.

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // Test chain of two X.509 certificates

--- a/jws.go
+++ b/jws.go
@@ -23,7 +23,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // rawJSONWebSignature represents a raw JWS JSON object. Used for parsing/serializing.

--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -21,9 +21,9 @@ import (
 	"bytes"
 	"reflect"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 
-	"github.com/square/go-jose"
+	"github.com/square/go-jose/v3"
 )
 
 // Builder is a utility for making JSON Web Tokens. Calls can be chained, and

--- a/jwt/builder_test.go
+++ b/jwt/builder_test.go
@@ -33,8 +33,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/square/go-jose"
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3"
+	"github.com/square/go-jose/v3/json"
 )
 
 type testClaims struct {

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // Claims represents public claim values (as specified in RFC 7519).

--- a/jwt/claims_test.go
+++ b/jwt/claims_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/jwt/example_test.go
+++ b/jwt/example_test.go
@@ -26,8 +26,8 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/square/go-jose"
-	"github.com/square/go-jose/jwt"
+	"github.com/square/go-jose/v3"
+	"github.com/square/go-jose/v3/jwt"
 )
 
 var sharedKey = []byte("secret")

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	jose "github.com/square/go-jose"
-	"github.com/square/go-jose/json"
+	jose "github.com/square/go-jose/v3"
+	"github.com/square/go-jose/v3/json"
 )
 
 // JSONWebToken represents a JSON Web Token (as specified in RFC7519).

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	jose "github.com/square/go-jose"
+	jose "github.com/square/go-jose/v3"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/shared.go
+++ b/shared.go
@@ -23,7 +23,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // KeyAlgorithm represents a key management algorithm.

--- a/signing.go
+++ b/signing.go
@@ -26,7 +26,7 @@ import (
 
 	"golang.org/x/crypto/ed25519"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 // NonceSource represents a source of random nonces to go into JWS objects

--- a/signing_test.go
+++ b/signing_test.go
@@ -26,7 +26,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/square/go-jose/json"
+	"github.com/square/go-jose/v3/json"
 )
 
 type staticNonceSource string

--- a/symmetric.go
+++ b/symmetric.go
@@ -32,7 +32,7 @@ import (
 
 	"golang.org/x/crypto/pbkdf2"
 
-	josecipher "github.com/square/go-jose/cipher"
+	josecipher "github.com/square/go-jose/v3/cipher"
 )
 
 // RandReader is a cryptographically secure random number generator (stubbed out in tests).


### PR DESCRIPTION
According to the Go modules [wiki
page](https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher),
both the module and import paths in the repo need to include the major
version for V2+ releases.

More details in discussion in #246 