### PR TITLE
Point jose-util at updated package.

### DIFF
--- a/jose-util/go.mod
+++ b/jose-util/go.mod
@@ -11,4 +11,4 @@ require (
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
-replace github.com/square/go-jose => ../
+replace github.com/square/go-jose/v3 => ../


### PR DESCRIPTION
Otherwise, it gets confused and downloads the version from github every time.