### PR TITLE
Change phrasing from "full serialization" to "JWE/JWS JSON Serialization"…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The implementation follows the
 [JSON Web Signature](http://dx.doi.org/10.17487/RFC7515) (RFC 7515), and
 [JSON Web Token](http://dx.doi.org/10.17487/RFC7519) (RFC 7519) specifications.
 Tables of supported algorithms are shown below. The library supports both
-the compact and full serialization formats, and has optional support for
+the compact and JWS/JWE JSON Serialization formats, and has optional support for
 multiple recipients. It also comes with a small command-line utility
 ([`jose-util`](https://github.com/square/go-jose/tree/master/jose-util))
 for dealing with JOSE messages in a shell.

--- a/doc.go
+++ b/doc.go
@@ -18,9 +18,9 @@
 
 Package jose aims to provide an implementation of the Javascript Object Signing
 and Encryption set of standards. It implements encryption and signing based on
-the JSON Web Encryption and JSON Web Signature standards, with optional JSON
-Web Token support available in a sub-package. The library supports both the
-compact and full serialization formats, and has optional support for multiple
+the JSON Web Encryption and JSON Web Signature standards, with optional JSON Web
+Token support available in a sub-package. The library supports both the compact
+and JWS/JWE JSON Serialization formats, and has optional support for multiple
 recipients.
 
 */

--- a/doc_test.go
+++ b/doc_test.go
@@ -50,7 +50,7 @@ func Example_jWE() {
 		panic(err)
 	}
 
-	// Serialize the encrypted object using the JWS JSON Serialization format.
+	// Serialize the encrypted object using the JWE JSON Serialization format.
 	// Alternatively you can also use the compact format here by calling
 	// object.CompactSerialize() instead.
 	serialized := object.FullSerialize()
@@ -193,7 +193,7 @@ func ExampleEncrypter_encrypt() {
 func ExampleEncrypter_encryptWithAuthData() {
 	// Encrypt a plaintext in order to get an encrypted JWE object. Also attach
 	// some additional authenticated data (AAD) to the object. Note that objects
-	// with attached AAD can only be represented using full serialization.
+	// with attached AAD can only be represented using JWE JSON Serialization.
 	var plaintext = []byte("This is a secret message")
 	var aad = []byte("This is authenticated, but public data")
 

--- a/doc_test.go
+++ b/doc_test.go
@@ -50,7 +50,7 @@ func Example_jWE() {
 		panic(err)
 	}
 
-	// Serialize the encrypted object using the full serialization format.
+	// Serialize the encrypted object using the JWS JSON Serialization format.
 	// Alternatively you can also use the compact format here by calling
 	// object.CompactSerialize() instead.
 	serialized := object.FullSerialize()
@@ -96,7 +96,7 @@ func Example_jWS() {
 		panic(err)
 	}
 
-	// Serialize the encrypted object using the full serialization format.
+	// Serialize the signed object using the JWS JSON Serialization format.
 	// Alternatively you can also use the compact format here by calling
 	// object.CompactSerialize() instead.
 	serialized := object.FullSerialize()

--- a/jose-util/README.md
+++ b/jose-util/README.md
@@ -25,7 +25,7 @@ signature algorithm (e.g. `PS256`).
 Input and output files can be specified via the `--in` and `--out` flags.
 Either flag can be omitted, in which case `jose-util` uses stdin/stdout for
 input/output respectively. By default each command will output a compact
-message, but it's possible to get the full serialization by supplying the
+message, but it's possible to get the JSON Serialization by supplying the
 `--full` flag.
 
 Keys are specified via the `--key` flag. Supported key types are naked RSA/EC
@@ -94,8 +94,8 @@ Reads a signed message (JWS), verifies it, and extracts the payload.
 
 Expands a compact message to the JWE/JWS JSON Serialization format.
 
-    jose-util expand --format JWE   # Expands a compact JWE to full format
-    jose-util expand --format JWS   # Expands a compact JWS to full format
+    jose-util expand --format JWE   # Expands a compact JWE to JWE JSON Serialization
+    jose-util expand --format JWS   # Expands a compact JWS to JWS JSON Serialization
 
 ### Decode base64
 

--- a/jose-util/README.md
+++ b/jose-util/README.md
@@ -92,7 +92,7 @@ Reads a signed message (JWS), verifies it, and extracts the payload.
 
 ### Expand
 
-Expands a compact message to the full serialization format.
+Expands a compact message to the JWE/JWS JSON Serialization format.
 
     jose-util expand --format JWE   # Expands a compact JWE to full format
     jose-util expand --format JWS   # Expands a compact JWS to full format

--- a/jose-util/jose-util.t
+++ b/jose-util/jose-util.t
@@ -87,7 +87,7 @@ Sign and verify a test message (EC).
   > jose-util verify --key ec.pub
   Lorem ipsum dolor sit amet
 
-Expand a compact message to full format.
+Expand a compact message to JSON format.
 
   $ echo "eyJhbGciOiJFUzM4NCJ9.TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQK.QPU35XY913Im7ZEaN2yHykfbtPqjHZvYp-lV8OcTAJZs67bJFSdTSkQhQWE9ch6tvYrj_7py6HKaWVFLll_s_Rm6bmwq3JszsHrIvFFm1NydruYHhvAnx7rjYiqwOu0W" |
   > jose-util expand --format JWS

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -53,7 +53,7 @@ var (
 	verifyCommand = app.Command("verify", "Verify a signed message, output payload")
 
 	// Expand
-	expandCommand    = app.Command("expand", "Expand JOSE object to full serialization format")
+	expandCommand    = app.Command("expand", "Expand JOSE object to JSON Serialization format")
 	expandFormatFlag = expandCommand.Flag("format", "Type of message to expand (JWS or JWE, defaults to JWE)").String()
 
 	// Base64-decode

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -39,7 +39,7 @@ var (
 	encryptCommand  = app.Command("encrypt", "Encrypt a plaintext, output ciphertext")
 	encryptAlgFlag  = encryptCommand.Flag("alg", "Key management algorithm (e.g. RSA-OAEP)").Required().String()
 	encryptEncFlag  = encryptCommand.Flag("enc", "Content encryption algorithm (e.g. A128GCM)").Required().String()
-	encryptFullFlag = encryptCommand.Flag("full", "Use full serialization format (instead of compact)").Bool()
+	encryptFullFlag = encryptCommand.Flag("full", "Use JSON Serialization format (instead of compact)").Bool()
 
 	// Decrypt
 	decryptCommand = app.Command("decrypt", "Decrypt a ciphertext, output plaintext")
@@ -47,7 +47,7 @@ var (
 	// Sign
 	signCommand  = app.Command("sign", "Sign a payload, output signed message")
 	signAlgFlag  = signCommand.Flag("alg", "Key management algorithm (e.g. RSA-OAEP)").Required().String()
-	signFullFlag = signCommand.Flag("full", "Use full serialization format (instead of compact)").Bool()
+	signFullFlag = signCommand.Flag("full", "Use JSON Serialization format (instead of compact)").Bool()
 
 	// Verify
 	verifyCommand = app.Command("verify", "Verify a signed message, output payload")

--- a/jwe.go
+++ b/jwe.go
@@ -104,7 +104,7 @@ func (obj JSONWebEncryption) computeAuthData() []byte {
 	return output
 }
 
-// ParseEncrypted parses an encrypted message in compact or full serialization format.
+// ParseEncrypted parses an encrypted message in compact or JWE JSON Serialization format.
 func ParseEncrypted(input string) (*JSONWebEncryption, error) {
 	input = stripWhitespace(input)
 	if strings.HasPrefix(input, "{") {

--- a/jwe_test.go
+++ b/jwe_test.go
@@ -321,7 +321,7 @@ func TestVectorsJWE(t *testing.T) {
 
 	serialized = object.FullSerialize()
 	if serialized != expectedFull {
-		t.Error("Full serialization is not what we expected")
+		t.Error("JSON serialization is not what we expected")
 	}
 }
 

--- a/jws.go
+++ b/jws.go
@@ -75,7 +75,7 @@ type Signature struct {
 	original  *rawSignatureInfo
 }
 
-// ParseSigned parses a signed message in compact or full serialization format.
+// ParseSigned parses a signed message in compact or JWS JSON Serialization format.
 func ParseSigned(signature string) (*JSONWebSignature, error) {
 	signature = stripWhitespace(signature)
 	if strings.HasPrefix(signature, "{") {

--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -36,7 +36,7 @@ type Builder interface {
 	Claims(i interface{}) Builder
 	// Token builds a JSONWebToken from provided data.
 	Token() (*JSONWebToken, error)
-	// FullSerialize serializes a token using the full serialization format.
+	// FullSerialize serializes a token using the JWS/JWE JSON Serialization format.
 	FullSerialize() (string, error)
 	// CompactSerialize serializes a token using the compact serialization format.
 	CompactSerialize() (string, error)
@@ -53,7 +53,7 @@ type NestedBuilder interface {
 	Claims(i interface{}) NestedBuilder
 	// Token builds a NestedJSONWebToken from provided data.
 	Token() (*NestedJSONWebToken, error)
-	// FullSerialize serializes a token using the full serialization format.
+	// FullSerialize serializes a token using the JSON Serialization format.
 	FullSerialize() (string, error)
 	// CompactSerialize serializes a token using the compact serialization format.
 	CompactSerialize() (string, error)


### PR DESCRIPTION
… where appropriate as per the RFC's.  

JSON serialization (JWS JSON Serialization and JWE JSON Serialization) is the only option other than compact serialization.  "Full serialization" isn't used in the RFC's and I found the phrasing confusing.  For example, JWT's only use compact serialization, so in this sense compact serialization is "full" since JSON serialization can not be used for JWT's while compact can be used for JWS's, JWE's, and JWT's.  

A great example of the JSON serialization terminology is section 3: https://tools.ietf.org/html/rfc7515#section-3

Here's an excerpt:

> This document defines two serializations for JWSs: a compact, URL-
>    safe serialization called the JWS Compact Serialization and a JSON
>    serialization called the JWS JSON Serialization.  In both
>    serializations, the JWS Protected Header, JWS Payload, and JWS
>    Signature are base64url encoded, since JSON lacks a way to directly
>    represent arbitrary octet sequences.