### PR TITLE
[v2] performance: Improve ParseSigned whitespace stripping

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -23,12 +23,11 @@ import (
 	"encoding/binary"
 	"io"
 	"math/big"
-	"regexp"
+	"strings"
+	"unicode"
 
 	"gopkg.in/square/go-jose.v2/json"
 )
-
-var stripWhitespaceRegex = regexp.MustCompile("\\s")
 
 // Helper function to serialize known-good objects.
 // Precondition: value is not a nil pointer.
@@ -56,7 +55,14 @@ func mustSerializeJSON(value interface{}) []byte {
 
 // Strip all newlines and whitespace
 func stripWhitespace(data string) string {
-	return stripWhitespaceRegex.ReplaceAllString(data, "")
+	buf := strings.Builder{}
+	buf.Grow(len(data))
+	for _, r := range data {
+		if !unicode.IsSpace(r) {
+			buf.WriteRune(r)
+		}
+	}
+	return buf.String()
 }
 
 // Perform compression based on algorithm

--- a/signing_test.go
+++ b/signing_test.go
@@ -570,3 +570,13 @@ func TestSignerB64(t *testing.T) {
 		t.Errorf("Input/output do not match, got '%s', expected '%s'", output, input)
 	}
 }
+
+func BenchmarkParseSigned(b *testing.B) {
+	msg := `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c`
+	for i := 0; i < b.N; i++ {
+		_, err := ParseSigned(msg)
+		if err != nil {
+			b.Errorf("Error on parse: %s", err)
+		}
+	}
+}


### PR DESCRIPTION
- When profiling some other code, I noticed ParseSigned wasn't as fast as I expected.
- Adds a benchmark for ParseSigned
- Replaces regexp to remove whitespace with a string.Builder approach.

`benchcmp` results for `go test -v -run=NONE -bench BenchmarkParseSigned -benchtime=30s -benchmem`
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkParseSigned-4     8184          5461          -33.27%

benchmark                  old allocs     new allocs     delta
BenchmarkParseSigned-4     50             48             -4.00%

benchmark                  old bytes     new bytes     delta
BenchmarkParseSigned-4     3832          3656          -4.59%
```
