### PR TITLE
Cherry-pick v3 PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.pem
 *.cov
 jose-util/jose-util
+jose-util.t.err

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,9 @@ script:
 - go test ./cipher -v -covermode=count -coverprofile=cipher/profile.cov
 - go test ./jwt -v -covermode=count -coverprofile=jwt/profile.cov
 - go test ./json -v # no coverage for forked encoding/json package
-- cd jose-util && go build && PATH=$PWD:$PATH cram -v jose-util.t
+- cd jose-util && go build && PATH=$PWD:$PATH cram -v jose-util.t # cram tests jose-util
 - cd ..
 
 after_success:
 - gocovmerge *.cov */*.cov > merged.coverprofile
 - $HOME/gopath/bin/goveralls -coverprofile merged.coverprofile -service=travis-ci
-

--- a/jose-util/README.md
+++ b/jose-util/README.md
@@ -25,6 +25,14 @@ Keys are specified via the `--key` flag. Supported key types are naked RSA/EC
 keys and X.509 certificates with embedded RSA/EC keys. Keys must be in PEM
 or DER formats.
 
+
+## Testing
+
+`cram` is used for testing.  This can be installed with pip or `sudo apt install
+python-cram` See the travis file for how this is used in testing. For example,
+`go build && PATH=$PWD:$PATH cram -v jose-util.t`
+
+
 ## Examples
 
 ### Encrypt

--- a/jose-util/jose-util.t
+++ b/jose-util/jose-util.t
@@ -1,4 +1,7 @@
-Set up test keys.
+This is a cram test file.  See the travis file for how this is used in testing.
+For example, `go build && PATH=$PWD:$PATH cram -v jose-util.t`
+
+Set up static test keys.
 
   $ cat > rsa.pub <<EOF
   > -----BEGIN PUBLIC KEY-----
@@ -61,28 +64,28 @@ Set up test keys.
 
 Encrypt and then decrypt a test message (RSA).
 
-  $ echo "Lorem ipsum dolor sit amet" | 
+  $ echo "Lorem ipsum dolor sit amet" |
   > jose-util encrypt --alg RSA-OAEP --enc A128GCM --key rsa.pub |
   > jose-util decrypt --key rsa.key
   Lorem ipsum dolor sit amet
 
 Encrypt and then decrypt a test message (EC).
 
-  $ echo "Lorem ipsum dolor sit amet" | 
+  $ echo "Lorem ipsum dolor sit amet" |
   > jose-util encrypt --alg ECDH-ES+A128KW --enc A128GCM --key ec.pub |
   > jose-util decrypt --key ec.key
   Lorem ipsum dolor sit amet
 
 Sign and verify a test message (RSA).
 
-  $ echo "Lorem ipsum dolor sit amet" | 
+  $ echo "Lorem ipsum dolor sit amet" |
   > jose-util sign --alg PS256 --key rsa.key |
   > jose-util verify --key rsa.pub
   Lorem ipsum dolor sit amet
 
 Sign and verify a test message (EC).
 
-  $ echo "Lorem ipsum dolor sit amet" | 
+  $ echo "Lorem ipsum dolor sit amet" |
   > jose-util sign --alg ES384 --key ec.key |
   > jose-util verify --key ec.pub
   Lorem ipsum dolor sit amet

--- a/jwk-keygen/main.go
+++ b/jwk-keygen/main.go
@@ -25,9 +25,10 @@ import (
 	"encoding/base32"
 	"errors"
 	"fmt"
-	"golang.org/x/crypto/ed25519"
 	"io"
 	"os"
+
+	"golang.org/x/crypto/ed25519"
 
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/square/go-jose.v2"
@@ -75,20 +76,32 @@ func KeygenSig(alg jose.SignatureAlgorithm, bits int) (crypto.PublicKey, crypto.
 	case jose.ES256:
 		// The cryptographic operations are implemented using constant-time algorithms.
 		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
 		return key.Public(), key, err
 	case jose.ES384:
 		// NB: The cryptographic operations do not use constant-time algorithms.
 		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
 		return key.Public(), key, err
 	case jose.ES512:
 		// NB: The cryptographic operations do not use constant-time algorithms.
 		key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
 		return key.Public(), key, err
 	case jose.EdDSA:
 		pub, key, err := ed25519.GenerateKey(rand.Reader)
 		return pub, key, err
 	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
 		key, err := rsa.GenerateKey(rand.Reader, bits)
+		if err != nil {
+			return nil, nil, err
+		}
 		return key.Public(), key, err
 	default:
 		return nil, nil, errors.New("unknown `alg` for `use` = `sig`")
@@ -106,6 +119,9 @@ func KeygenEnc(alg jose.KeyAlgorithm, bits int) (crypto.PublicKey, crypto.Privat
 			return nil, nil, errors.New("too short key for RSA `alg`, 2048+ is required")
 		}
 		key, err := rsa.GenerateKey(rand.Reader, bits)
+		if err != nil {
+			return nil, nil, err
+		}
 		return key.Public(), key, err
 	case jose.ECDH_ES, jose.ECDH_ES_A128KW, jose.ECDH_ES_A192KW, jose.ECDH_ES_A256KW:
 		var crv elliptic.Curve
@@ -120,6 +136,9 @@ func KeygenEnc(alg jose.KeyAlgorithm, bits int) (crypto.PublicKey, crypto.Privat
 			return nil, nil, errors.New("unknown elliptic curve bit length, use one of 256, 384, 521")
 		}
 		key, err := ecdsa.GenerateKey(crv, rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
 		return key.Public(), key, err
 	default:
 		return nil, nil, errors.New("unknown `alg` for `use` = `enc`")

--- a/jwk.go
+++ b/jwk.go
@@ -17,15 +17,19 @@
 package jose
 
 import (
+	"bytes"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"math/big"
+	"net/url"
 	"reflect"
 	"strings"
 
@@ -57,16 +61,31 @@ type rawJSONWebKey struct {
 	Dq *byteBuffer `json:"dq,omitempty"`
 	Qi *byteBuffer `json:"qi,omitempty"`
 	// Certificates
-	X5c []string `json:"x5c,omitempty"`
+	X5c       []string    `json:"x5c,omitempty"`
+	X5u       *url.URL    `json:"x5u,omitempty"`
+	X5tSHA1   *byteBuffer `json:"x5t,omitempty"`
+	X5tSHA256 *byteBuffer `json:"x5t#S256,omitempty"`
 }
 
 // JSONWebKey represents a public or private key in JWK format.
 type JSONWebKey struct {
-	Key          interface{}
+	// Cryptographic key, can be a symmetric or asymmetric key.
+	Key interface{}
+	// Key identifier, parsed from `kid` header.
+	KeyID string
+	// Key algorithm, parsed from `alg` header.
+	Algorithm string
+	// Key use, parsed from `use` header.
+	Use string
+
+	// X.509 certificate chain, parsed from `x5c` header.
 	Certificates []*x509.Certificate
-	KeyID        string
-	Algorithm    string
-	Use          string
+	// X.509 certificate URL, parsed from `x5u` header.
+	CertificatesURL *url.URL
+	// X.509 certificate thumbprint (SHA-1), parsed from `x5t` header.
+	CertificateThumbprintSHA1 []byte
+	// X.509 certificate thumbprint (SHA-256), parsed from `x5t#S256` header.
+	CertificateThumbprintSHA256 []byte
 }
 
 // MarshalJSON serializes the given key to its JSON representation.
@@ -105,6 +124,36 @@ func (k JSONWebKey) MarshalJSON() ([]byte, error) {
 		raw.X5c = append(raw.X5c, base64.StdEncoding.EncodeToString(cert.Raw))
 	}
 
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 {
+		if x5tSHA1Len != sha1.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-1 thumbprint (must be %d bytes, not %d)", sha1.Size, x5tSHA1Len)
+		}
+		raw.X5tSHA1 = newFixedSizeBuffer(k.CertificateThumbprintSHA1, sha1.Size)
+	}
+	if x5tSHA256Len > 0 {
+		if x5tSHA256Len != sha256.Size {
+			return nil, fmt.Errorf("square/go-jose: invalid SHA-256 thumbprint (must be %d bytes, not %d)", sha256.Size, x5tSHA256Len)
+		}
+		raw.X5tSHA256 = newFixedSizeBuffer(k.CertificateThumbprintSHA256, sha256.Size)
+	}
+
+	// If cert chain is attached (as opposed to being behind a URL), check the
+	// keys thumbprints to make sure they match what is expected. This is to
+	// ensure we don't accidentally produce a JWK with semantically inconsistent
+	// data in the headers.
+	if len(k.Certificates) > 0 {
+		expectedSHA1 := sha1.Sum(k.Certificates[0].Raw)
+		expectedSHA256 := sha256.Sum256(k.Certificates[0].Raw)
+		if !bytes.Equal(k.CertificateThumbprintSHA1, expectedSHA1[:]) ||
+			!bytes.Equal(k.CertificateThumbprintSHA256, expectedSHA256[:]) {
+			return nil, errors.New("square/go-jose: invalid SHA-1 or SHA-256 thumbprint, does not match cert chain")
+		}
+	}
+
+	raw.X5u = k.CertificatesURL
+
 	return json.Marshal(raw)
 }
 
@@ -116,28 +165,61 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		return err
 	}
 
+	certs, err := parseCertificateChain(raw.X5c)
+	if err != nil {
+		return fmt.Errorf("square/go-jose: failed to unmarshal x5c field: %s", err)
+	}
+
 	var key interface{}
+	var certPub interface{}
+	var keyPub interface{}
+
+	if len(certs) > 0 {
+		// We need to check that leaf public key matches the key embedded in this
+		// JWK, as required by the standard (see RFC 7517, Section 4.7). Otherwise
+		// the JWK parsed could be semantically invalid. Technically, should also
+		// check key usage fields and other extensions on the cert here, but the
+		// standard doesn't exactly explain how they're supposed to map from the
+		// JWK representation to the X.509 extensions.
+		certPub = certs[0].PublicKey
+	}
+
 	switch raw.Kty {
 	case "EC":
 		if raw.D != nil {
 			key, err = raw.ecPrivateKey()
+			if err == nil {
+				keyPub = key.(*ecdsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.ecPublicKey()
+			keyPub = key
 		}
 	case "RSA":
 		if raw.D != nil {
 			key, err = raw.rsaPrivateKey()
+			if err == nil {
+				keyPub = key.(*rsa.PrivateKey).Public()
+			}
 		} else {
 			key, err = raw.rsaPublicKey()
+			keyPub = key
 		}
 	case "oct":
+		if certPub != nil {
+			return errors.New("square/go-jose: invalid JWK, found 'oct' (symmetric) key with cert chain")
+		}
 		key, err = raw.symmetricKey()
 	case "OKP":
 		if raw.Crv == "Ed25519" && raw.X != nil {
 			if raw.D != nil {
 				key, err = raw.edPrivateKey()
+				if err == nil {
+					keyPub = key.(ed25519.PrivateKey).Public()
+				}
 			} else {
 				key, err = raw.edPublicKey()
+				keyPub = key
 			}
 		} else {
 			err = fmt.Errorf("square/go-jose: unknown curve %s'", raw.Crv)
@@ -146,12 +228,43 @@ func (k *JSONWebKey) UnmarshalJSON(data []byte) (err error) {
 		err = fmt.Errorf("square/go-jose: unknown json web key type '%s'", raw.Kty)
 	}
 
-	if err == nil {
-		*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use}
+	if err != nil {
+		return
+	}
 
-		k.Certificates, err = parseCertificateChain(raw.X5c)
-		if err != nil {
-			return fmt.Errorf("failed to unmarshal x5c field: %s", err)
+	if certPub != nil && keyPub != nil {
+		if !reflect.DeepEqual(certPub, keyPub) {
+			return errors.New("square/go-jose: invalid JWK, public keys in key and x5c fields to not match")
+		}
+	}
+
+	*k = JSONWebKey{Key: key, KeyID: raw.Kid, Algorithm: raw.Alg, Use: raw.Use, Certificates: certs}
+
+	k.CertificatesURL = raw.X5u
+	k.CertificateThumbprintSHA1 = raw.X5tSHA1.bytes()
+	k.CertificateThumbprintSHA256 = raw.X5tSHA256.bytes()
+
+	x5tSHA1Len := len(k.CertificateThumbprintSHA1)
+	x5tSHA256Len := len(k.CertificateThumbprintSHA256)
+	if x5tSHA1Len > 0 && x5tSHA1Len != sha1.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t header is of incorrect size")
+	}
+	if x5tSHA256Len > 0 && x5tSHA256Len != sha256.Size {
+		return errors.New("square/go-jose: invalid JWK, x5t header is of incorrect size")
+	}
+
+	// If certificate chain *and* thumbprints are set, verify correctness.
+	if len(k.Certificates) > 0 {
+		leaf := k.Certificates[0]
+		sha1sum := sha1.Sum(leaf.Raw)
+		sha256sum := sha256.Sum256(leaf.Raw)
+
+		if len(k.CertificateThumbprintSHA1) > 0 && !bytes.Equal(sha1sum[:], k.CertificateThumbprintSHA1) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t value")
+		}
+
+		if len(k.CertificateThumbprintSHA256) > 0 && !bytes.Equal(sha256sum[:], k.CertificateThumbprintSHA256) {
+			return errors.New("square/go-jose: invalid JWK, x5c thumbprint does not match x5t#S256 value")
 		}
 	}
 

--- a/jws_test.go
+++ b/jws_test.go
@@ -217,7 +217,7 @@ func TestVerifyFlattenedWithIncludedUnprotectedKey(t *testing.T) {
 
 	jws, err := ParseSigned(input)
 	if err != nil {
-		t.Error("Unable to parse valid message.")
+		t.Fatal("Unable to parse valid message", err)
 	}
 	if len(jws.Signatures) != 1 {
 		t.Error("Too many or too few signatures.")

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -80,7 +80,7 @@ func (n *NumericDate) Time() time.Time {
 	return time.Unix(int64(*n), 0)
 }
 
-// Audience represents the recipents that the token is intended for.
+// Audience represents the recipients that the token is intended for.
 type Audience []string
 
 // UnmarshalJSON reads an audience from its JSON representation.

--- a/jwt/validation.go
+++ b/jwt/validation.go
@@ -35,7 +35,7 @@ type Expected struct {
 	Audience Audience
 	// ID matches the "jti" claim exactly.
 	ID string
-	// Time matches the "exp" and "nbf" claims with leeway.
+	// Time matches the "exp", "nbf" and "iat" claims with leeway.
 	Time time.Time
 }
 


### PR DESCRIPTION
I found that a number of PRs, that were **applicable to v2,** had **only been merged to master** (current v3 dev branch) -- this issue has been documented in #290.

This PR brings the following changes to v2:
- #242
- #250
- #269
- #274
- #280
- #289

It might be worth pointing out that some changes had to be back-ported manually (jose-util changes).
