### PR TITLE
travis: update config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - nakedret
     - scopelint
     - unparam
+    - funlen # added in 1.18 (requires go-jose changes before it can be enabled)
 
 linters-settings:
   gocyclo:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,21 @@
 language: go
 
-dist: xenial
-sudo: false
-
 matrix:
   fast_finish: true
   allow_failures:
     - go: tip
 
 go:
-  - "1.11.x"
-  - "1.12.x"
+  - "1.13.x"
+  - "1.14.x"
   - tip
-
-env:
-  - GO111MODULE=on
 
 before_script:
   - export PATH=$HOME/.local/bin:$PATH
 
 before_install:
   - go get -u github.com/mattn/goveralls github.com/wadey/gocovmerge
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.16.0
+  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.18.0
   - pip install cram --user
 
 script:


### PR DESCRIPTION
- Test against supported Go versions (Go 1.13 and 1.14), which also
  means we don't need GO111MODULE anymore
- Remove old options like 'sudo: false'
- Bump golangci-lint to 1.18.0, so it works with Go 1.13+ (see
  https://github.com/golangci/golangci-lint/issues/658 for details)