### PR TITLE
Export jose-util helpers

### DIFF
--- a/jose-util/crypto.go
+++ b/jose-util/crypto.go
@@ -16,10 +16,13 @@
 
 package main
 
-import jose "github.com/square/go-jose/v3"
+import (
+	jose "github.com/square/go-jose/v3"
+	"github.com/square/go-jose/jose-util/generator"
+)
 
 func encrypt() {
-	pub, err := LoadPublicKey(keyBytes())
+	pub, err := generator.LoadPublicKey(keyBytes())
 	app.FatalIfError(err, "unable to read public key")
 
 	alg := jose.KeyAlgorithm(*encryptAlgFlag)
@@ -43,7 +46,7 @@ func encrypt() {
 }
 
 func decrypt() {
-	priv, err := LoadPrivateKey(keyBytes())
+	priv, err := generator.LoadPrivateKey(keyBytes())
 	app.FatalIfError(err, "unable to read private key")
 
 	obj, err := jose.ParseEncrypted(string(readInput(*inFile)))
@@ -56,7 +59,7 @@ func decrypt() {
 }
 
 func sign() {
-	signingKey, err := LoadPrivateKey(keyBytes())
+	signingKey, err := generator.LoadPrivateKey(keyBytes())
 	app.FatalIfError(err, "unable to read private key")
 
 	alg := jose.SignatureAlgorithm(*signAlgFlag)
@@ -78,7 +81,7 @@ func sign() {
 }
 
 func verify() {
-	verificationKey, err := LoadPublicKey(keyBytes())
+	verificationKey, err := generator.LoadPublicKey(keyBytes())
 	app.FatalIfError(err, "unable to read public key")
 
 	obj, err := jose.ParseSigned(string(readInput(*inFile)))

--- a/jose-util/generate.go
+++ b/jose-util/generate.go
@@ -18,108 +18,13 @@ package main
 
 import (
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/rsa"
 	"encoding/base64"
 	"errors"
 	"fmt"
 
-	jose "github.com/square/go-jose/v3"
+	"github.com/square/go-jose/v3"
+	"github.com/square/go-jose/jose-util/generator"
 )
-
-// GenerateSigningKey generates a keypair for corresponding SignatureAlgorithm.
-func GenerateSigningKey(alg jose.SignatureAlgorithm, bits int) (crypto.PublicKey, crypto.PrivateKey, error) {
-	switch alg {
-	case jose.ES256, jose.ES384, jose.ES512, jose.EdDSA:
-		keylen := map[jose.SignatureAlgorithm]int{
-			jose.ES256: 256,
-			jose.ES384: 384,
-			jose.ES512: 521, // sic!
-			jose.EdDSA: 256,
-		}
-		if bits != 0 && bits != keylen[alg] {
-			return nil, nil, errors.New("invalid elliptic curve key size, this algorithm does not support arbitrary size")
-		}
-	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
-		if bits == 0 {
-			bits = 2048
-		}
-		if bits < 2048 {
-			return nil, nil, errors.New("invalid key size for RSA key, 2048 or more is required")
-		}
-	}
-	switch alg {
-	case jose.ES256:
-		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-		if err != nil {
-			return nil, nil, err
-		}
-		return key.Public(), key, err
-	case jose.ES384:
-		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-		if err != nil {
-			return nil, nil, err
-		}
-		return key.Public(), key, err
-	case jose.ES512:
-		key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
-		if err != nil {
-			return nil, nil, err
-		}
-		return key.Public(), key, err
-	case jose.EdDSA:
-		pub, key, err := ed25519.GenerateKey(rand.Reader)
-		return pub, key, err
-	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
-		key, err := rsa.GenerateKey(rand.Reader, bits)
-		if err != nil {
-			return nil, nil, err
-		}
-		return key.Public(), key, err
-	default:
-		return nil, nil, fmt.Errorf("unknown algorithm %s for signing key", alg)
-	}
-}
-
-// GenerateEncryptionKey generates a keypair for corresponding KeyAlgorithm.
-func GenerateEncryptionKey(alg jose.KeyAlgorithm, bits int) (crypto.PublicKey, crypto.PrivateKey, error) {
-	switch alg {
-	case jose.RSA1_5, jose.RSA_OAEP, jose.RSA_OAEP_256:
-		if bits == 0 {
-			bits = 2048
-		}
-		if bits < 2048 {
-			return nil, nil, errors.New("invalid key size for RSA key, 2048 or more is required")
-		}
-		key, err := rsa.GenerateKey(rand.Reader, bits)
-		if err != nil {
-			return nil, nil, err
-		}
-		return key.Public(), key, err
-	case jose.ECDH_ES, jose.ECDH_ES_A128KW, jose.ECDH_ES_A192KW, jose.ECDH_ES_A256KW:
-		var crv elliptic.Curve
-		switch bits {
-		case 0, 256:
-			crv = elliptic.P256()
-		case 384:
-			crv = elliptic.P384()
-		case 521:
-			crv = elliptic.P521()
-		default:
-			return nil, nil, errors.New("invalid elliptic curve key size, use one of 256, 384, or 521")
-		}
-		key, err := ecdsa.GenerateKey(crv, rand.Reader)
-		if err != nil {
-			return nil, nil, err
-		}
-		return key.Public(), key, err
-	default:
-		return nil, nil, fmt.Errorf("unknown algorithm %s for encryption key", alg)
-	}
-}
 
 func generate() {
 	var privKey crypto.PrivateKey
@@ -128,9 +33,9 @@ func generate() {
 
 	switch *generateUseFlag {
 	case "sig":
-		pubKey, privKey, err = GenerateSigningKey(jose.SignatureAlgorithm(*generateAlgFlag), *generateKeySizeFlag)
+		pubKey, privKey, err = generator.NewSigningKey(jose.SignatureAlgorithm(*generateAlgFlag), *generateKeySizeFlag)
 	case "enc":
-		pubKey, privKey, err = GenerateEncryptionKey(jose.KeyAlgorithm(*generateAlgFlag), *generateKeySizeFlag)
+		pubKey, privKey, err = generator.NewEncryptionKey(jose.KeyAlgorithm(*generateAlgFlag), *generateKeySizeFlag)
 	default:
 		// According to RFC 7517 section-8.2.  This is unlikely to change in the
 		// near future. If it were, new values could be found in the registry under

--- a/jose-util/generator/encoding.go
+++ b/jose-util/generator/encoding.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package main
+package generator
 
 import "io"
 
@@ -23,11 +23,11 @@ import "io"
 // to read any base64-encoded data as input, whether padded, unpadded, standard or
 // url-safe.
 type Base64Reader struct {
-	in io.Reader
+	In io.Reader
 }
 
 func (r Base64Reader) Read(p []byte) (n int, err error) {
-	n, err = r.in.Read(p)
+	n, err = r.In.Read(p)
 
 	for i := 0; i < n; i++ {
 		switch p[i] {

--- a/jose-util/generator/generate.go
+++ b/jose-util/generator/generate.go
@@ -1,0 +1,121 @@
+/*-
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generator
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+
+	jose "github.com/square/go-jose/v3"
+)
+
+// NewSigningKey generates a keypair for corresponding SignatureAlgorithm.
+func NewSigningKey(alg jose.SignatureAlgorithm, bits int) (crypto.PublicKey, crypto.PrivateKey, error) {
+	switch alg {
+	case jose.ES256, jose.ES384, jose.ES512, jose.EdDSA:
+		keylen := map[jose.SignatureAlgorithm]int{
+			jose.ES256: 256,
+			jose.ES384: 384,
+			jose.ES512: 521, // sic!
+			jose.EdDSA: 256,
+		}
+		if bits != 0 && bits != keylen[alg] {
+			return nil, nil, errors.New("invalid elliptic curve key size, this algorithm does not support arbitrary size")
+		}
+	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
+		if bits == 0 {
+			bits = 2048
+		}
+		if bits < 2048 {
+			return nil, nil, errors.New("invalid key size for RSA key, 2048 or more is required")
+		}
+	}
+	switch alg {
+	case jose.ES256:
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return key.Public(), key, err
+	case jose.ES384:
+		key, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return key.Public(), key, err
+	case jose.ES512:
+		key, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return key.Public(), key, err
+	case jose.EdDSA:
+		pub, key, err := ed25519.GenerateKey(rand.Reader)
+		return pub, key, err
+	case jose.RS256, jose.RS384, jose.RS512, jose.PS256, jose.PS384, jose.PS512:
+		key, err := rsa.GenerateKey(rand.Reader, bits)
+		if err != nil {
+			return nil, nil, err
+		}
+		return key.Public(), key, err
+	default:
+		return nil, nil, fmt.Errorf("unknown algorithm %s for signing key", alg)
+	}
+}
+
+// NewEncryptionKey generates a keypair for corresponding KeyAlgorithm.
+func NewEncryptionKey(alg jose.KeyAlgorithm, bits int) (crypto.PublicKey, crypto.PrivateKey, error) {
+	switch alg {
+	case jose.RSA1_5, jose.RSA_OAEP, jose.RSA_OAEP_256:
+		if bits == 0 {
+			bits = 2048
+		}
+		if bits < 2048 {
+			return nil, nil, errors.New("invalid key size for RSA key, 2048 or more is required")
+		}
+		key, err := rsa.GenerateKey(rand.Reader, bits)
+		if err != nil {
+			return nil, nil, err
+		}
+		return key.Public(), key, err
+	case jose.ECDH_ES, jose.ECDH_ES_A128KW, jose.ECDH_ES_A192KW, jose.ECDH_ES_A256KW:
+		var crv elliptic.Curve
+		switch bits {
+		case 0, 256:
+			crv = elliptic.P256()
+		case 384:
+			crv = elliptic.P384()
+		case 521:
+			crv = elliptic.P521()
+		default:
+			return nil, nil, errors.New("invalid elliptic curve key size, use one of 256, 384, or 521")
+		}
+		key, err := ecdsa.GenerateKey(crv, rand.Reader)
+		if err != nil {
+			return nil, nil, err
+		}
+		return key.Public(), key, err
+	default:
+		return nil, nil, fmt.Errorf("unknown algorithm %s for encryption key", alg)
+	}
+}

--- a/jose-util/generator/utils.go
+++ b/jose-util/generator/utils.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package main
+package generator
 
 import (
 	"crypto/x509"

--- a/jose-util/main.go
+++ b/jose-util/main.go
@@ -23,8 +23,10 @@ import (
 	"io"
 	"os"
 
-	jose "github.com/square/go-jose/v3"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	jose "github.com/square/go-jose/v3"
+	generator "github.com/square/go-jose/jose-util/generator"
 )
 
 var (
@@ -98,7 +100,7 @@ func main() {
 	case base64DecodeCommand.FullCommand():
 		in := inputStream(*inFile)
 		out := outputStream(*outFile)
-		io.Copy(out, base64.NewDecoder(base64.RawStdEncoding, Base64Reader{bufio.NewReader(in)}))
+		io.Copy(out, base64.NewDecoder(base64.RawStdEncoding, generator.Base64Reader{In: bufio.NewReader(in)}))
 		defer in.Close()
 		defer out.Close()
 	default:


### PR DESCRIPTION
The utils for key generations are very helpful in other projects as well. Exporting them seems like a good idea without any downsides as the code is properly tested.