### PR TITLE
Support for deferring critical headers to the caller for validation.

### DIFF
--- a/jwt/builder.go
+++ b/jwt/builder.go
@@ -191,7 +191,7 @@ func (b *signedBuilder) Token() (*JSONWebToken, error) {
 		h[i] = v.Header
 	}
 
-	return b.builder.token(sig.Verify, h)
+	return b.builder.token(sig.Verifier(), h)
 }
 
 func (b *signedBuilder) CompactSerialize() (string, error) {

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -99,7 +99,7 @@ func ParseSigned(s string) (*JSONWebToken, error) {
 	}
 
 	return &JSONWebToken{
-		payload:           sig.Verify,
+		payload:           sig.Verifier(),
 		unverifiedPayload: sig.UnsafePayloadWithoutVerification,
 		Headers:           headers,
 	}, nil

--- a/signing_test.go
+++ b/signing_test.go
@@ -594,3 +594,28 @@ func BenchmarkParseSigned(b *testing.B) {
 		}
 	}
 }
+
+// Test that unknown critical headers are allowed if the calling code promises to verify them
+func TestDeferredCritical(t *testing.T) {
+	opts := &SignerOptions{}
+
+	signer, err := NewSigner(SigningKey{PS256, rsaTestKey}, opts.WithCritical("exp").WithHeader("exp", 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	obj, err := signer.Sign([]byte("Lorem ipsum dolor sit amet"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = obj.Verify(&rsaTestKey.PublicKey, WithDeferred("exp"))
+	if err != nil {
+		t.Error("should verify message with deferred critical header")
+	}
+
+	_, err = obj.Verify(&rsaTestKey.PublicKey)
+	if err == nil {
+		t.Error("should not verify message with unknown crit header")
+	}
+}


### PR DESCRIPTION
Here's an attempt to solve #288.

I've used functional options (https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md) in order to add options to the Verify*-functions without breaking backwards compatibility.

