### PR TITLE
jwt.NumericDate: Correct doc comment to "ignoring leap seconds"

### DIFF
--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -36,8 +36,9 @@ type Claims struct {
 }
 
 // NumericDate represents date and time as the number of seconds since the
-// epoch, including leap seconds. Non-integer values can be represented
+// epoch, ignoring leap seconds. Non-integer values can be represented
 // in the serialized format, but we round to the nearest second.
+// See RFC7519 Section 2: https://tools.ietf.org/html/rfc7519#section-2
 type NumericDate int64
 
 // NewNumericDate constructs NumericDate from time.Time value.


### PR DESCRIPTION
The JWT NumericDate type is a Unix/POSIX timestamp, which ignores leap
seconds as far as I know. This said "including leap seconds" which was
confusing. Use "ignoring leap seconds" which is direct from the RFC:

RFC7519 Section 2 states:
https://tools.ietf.org/html/rfc7519#section-2

    A JSON numeric value representing the number of seconds from
    1970-01-01T00:00:00Z UTC until the specified UTC date/time,
    ignoring leap seconds.  This is equivalent to the IEEE Std 1003.1,
    2013 Edition [POSIX.1] definition "Seconds Since the Epoch", in
    which each day is accounted for by exactly 86400 seconds, other
    than that non-integer values can be represented.