### PR TITLE
jwt: Claims.Validate: Clarify that you must set e.Time

### DIFF
--- a/jwt/validation.go
+++ b/jwt/validation.go
@@ -47,6 +47,8 @@ func (e Expected) WithTime(t time.Time) Expected {
 
 // Validate checks claims in a token against expected values.
 // A default leeway value of one minute is used to compare time values.
+// Set e.Time to the current time, otherwise the Expiry, IssuedAt and
+// NotBefore claims will be ignored.
 //
 // The default leeway will cause the token to be deemed valid until one
 // minute after the expiration time. If you're a server application that


### PR DESCRIPTION
The default arguments to Validate ignore the timestamps in the JWT.
This makes sense, but is a dangerous default, since users may not
realize that the timestamps in their JWTs are not being checked.
Clarify the documentation to try and make this error less common.