### PR TITLE
jwt: Claims.Validate: Treat zero Expected.Time as now

### DIFF
--- a/jwt/validation.go
+++ b/jwt/validation.go
@@ -25,7 +25,9 @@ const (
 )
 
 // Expected defines values used for protected claims validation.
-// If field has zero value then validation is skipped.
+// If field has zero value then validation is skipped, with the exception of
+// Time, where the zero value means "now." To skip validating them, set the
+// corresponding field in the Claims struct to nil.
 type Expected struct {
 	// Issuer matches the "iss" claim exactly.
 	Issuer string
@@ -61,7 +63,7 @@ func (c Claims) Validate(e Expected) error {
 
 // ValidateWithLeeway checks claims in a token against expected values. A
 // custom leeway may be specified for comparing time values. You may pass a
-// zero value to check time values with no leeway, but you should not that
+// zero value to check time values with no leeway, but you should note that
 // numeric date values are rounded to the nearest second and sub-second
 // precision is not supported.
 //
@@ -94,20 +96,24 @@ func (c Claims) ValidateWithLeeway(e Expected, leeway time.Duration) error {
 		}
 	}
 
-	if !e.Time.IsZero() {
-		if c.NotBefore != nil && e.Time.Add(leeway).Before(c.NotBefore.Time()) {
-			return ErrNotValidYet
-		}
+	// validate using the e.Time, or time.Now if not provided
+	validationTime := e.Time
+	if validationTime.IsZero() {
+		validationTime = time.Now()
+	}
 
-		if c.Expiry != nil && e.Time.Add(-leeway).After(c.Expiry.Time()) {
-			return ErrExpired
-		}
+	if c.NotBefore != nil && validationTime.Add(leeway).Before(c.NotBefore.Time()) {
+		return ErrNotValidYet
+	}
 
-		// IssuedAt is optional but cannot be in the future. This is not required by the RFC, but
-		// something is misconfigured if this happens and we should not trust it.
-		if c.IssuedAt != nil && e.Time.Add(leeway).Before(c.IssuedAt.Time()) {
-			return ErrIssuedInTheFuture
-		}
+	if c.Expiry != nil && validationTime.Add(-leeway).After(c.Expiry.Time()) {
+		return ErrExpired
+	}
+
+	// IssuedAt is optional but cannot be in the future. This is not required by the RFC, but
+	// something is misconfigured if this happens and we should not trust it.
+	if c.IssuedAt != nil && validationTime.Add(leeway).Before(c.IssuedAt.Time()) {
+		return ErrIssuedInTheFuture
 	}
 
 	return nil

--- a/jwt/validation_test.go
+++ b/jwt/validation_test.go
@@ -142,7 +142,7 @@ func TestOptionalDateClaims(t *testing.T) {
 		},
 		{
 			"fail nbf",
-			Claims{NotBefore: NewNumericDate(time.Now())},
+			Claims{NotBefore: NewNumericDate(time.Now().Add(2 * time.Minute))},
 			ErrNotValidYet,
 		},
 		{
@@ -152,7 +152,7 @@ func TestOptionalDateClaims(t *testing.T) {
 		},
 		{
 			"fail iat",
-			Claims{IssuedAt: NewNumericDate(time.Now())},
+			Claims{IssuedAt: NewNumericDate(time.Now().Add(2 * time.Minute))},
 			ErrIssuedInTheFuture,
 		},
 	}
@@ -161,6 +161,11 @@ func TestOptionalDateClaims(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			expect := Expected{}.WithTime(epoch.Add(-24 * time.Hour))
 			err := tc.claim.Validate(expect)
+			assert.Equal(t, tc.want, err)
+
+			// test with zero expected time: should not change anything
+			expect = Expected{}
+			err = tc.claim.Validate(expect)
 			assert.Equal(t, tc.want, err)
 		})
 	}


### PR DESCRIPTION
This ensures we always validate the exp/iat/nbf fields. Previously,
if the caller forgot to set the Time field, they were ignored. This is
a very easy and critical security bug. Users who want to ignore these
fields can still set the corresponding Claims fields to nil.