### PR TITLE
jwt/validation_test.go: More coverage for leeway

### DIFF
--- a/jwt/validation_test.go
+++ b/jwt/validation_test.go
@@ -75,6 +75,8 @@ func TestExpiryAndNotBefore(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Equal(t, err, ErrExpired)
 	}
+	// some error is okay (leeway)
+	assert.NoError(t, c.Validate(Expected{Time: now.Add(DefaultLeeway)}))
 
 	// expired - no leeway
 	assert.NoError(t, c.ValidateWithLeeway(Expected{Time: now}, 0))
@@ -89,6 +91,8 @@ func TestExpiryAndNotBefore(t *testing.T) {
 	if assert.Error(t, err) {
 		assert.Equal(t, err, ErrNotValidYet)
 	}
+	// some error is okay (leeway)
+	assert.NoError(t, c.Validate(Expected{Time: twelveHoursAgo.Add(-DefaultLeeway)}))
 }
 
 func TestIssuedInFuture(t *testing.T) {


### PR DESCRIPTION
While looking at the tests for ValidateWithLeeway, I noticed it was
missing coverage to verify that it correctly applies the leeway to
the NotBefore and Expiry claims. There were tests for IssuedAt.