### PR TITLE
fix: add ExtraHeaders from options object to multi encrypter

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -216,6 +216,7 @@ func NewMultiEncrypter(enc ContentEncryption, rcpts []Recipient, opts *Encrypter
 
 	if opts != nil {
 		encrypter.compressionAlg = opts.Compression
+		encrypter.extraHeaders = opts.ExtraHeaders
 	}
 
 	for _, recipient := range rcpts {


### PR DESCRIPTION
Attempts to fix #337 in a very naive way.