### PR TITLE
Add support for non-pointer jose.JSONWebKeySet

### DIFF
--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -137,8 +137,14 @@ func ParseSignedAndEncrypted(s string) (*NestedJSONWebToken, error) {
 }
 
 func tryJWKS(headers []jose.Header, key interface{}) interface{} {
-	jwks, ok := key.(*jose.JSONWebKeySet)
-	if !ok {
+	var jwks jose.JSONWebKeySet
+
+	switch jwksType := key.(type) {
+	case *jose.JSONWebKeySet:
+		jwks = *jwksType
+	case jose.JSONWebKeySet:
+		jwks = jwksType
+	default:
 		return key
 	}
 

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -81,12 +81,19 @@ func TestDecodeTokenWithJWKS(t *testing.T) {
 	tok, err := ParseSigned(rsaSignedTokenWithKid)
 	if assert.NoError(t, err, "Error parsing signed token.") {
 		cl := make(map[string]interface{})
+		expected := map[string]interface{}{
+			"sub":    "subject",
+			"iss":    "issuer",
+			"scopes": []interface{}{"s1", "s2"},
+		}
+
 		if assert.NoError(t, tok.Claims(jwks, &cl)) {
-			assert.Equal(t, map[string]interface{}{
-				"sub":    "subject",
-				"iss":    "issuer",
-				"scopes": []interface{}{"s1", "s2"},
-			}, cl)
+			assert.Equal(t, expected, cl)
+		}
+
+		cl = make(map[string]interface{})
+		if assert.NoError(t, tok.Claims(*jwks, &cl)) {
+			assert.Equal(t, expected, cl)
 		}
 	}
 }


### PR DESCRIPTION
I found that it throws an error when you don't send it as a pointer and later I saw that it was not supported in the code, which seemed strange to me because to sign [JSONWebKey pointer or non-pointer](https://github.com/square/go-jose/blob/5c87222f69b2401c305bcb103b875524e13de347/signing.go#L173) are supported. So I just add it :)