### PR TITLE
RFC: Support parsing without payload

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -332,7 +332,7 @@ func (s *JSONWebKeySet) Key(kid string) []JSONWebKey {
 
 const rsaThumbprintTemplate = `{"e":"%s","kty":"RSA","n":"%s"}`
 const ecThumbprintTemplate = `{"crv":"%s","kty":"EC","x":"%s","y":"%s"}`
-const edThumbprintTemplate = `{"crv":"%s","kty":"OKP",x":"%s"}`
+const edThumbprintTemplate = `{"crv":"%s","kty":"OKP","x":"%s"}`
 
 func ecThumbprintInput(curve elliptic.Curve, x, y *big.Int) (string, error) {
 	coordLength := curveSize(curve)

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -760,7 +760,7 @@ var cookbookJWKs = []string{
 // SHA-256 thumbprints of the above keys, hex-encoded
 var cookbookJWKThumbprints = []string{
 	"747ae2dd2003664aeeb21e4753fe7402846170a16bc8df8f23a8cf06d3cbe793",
-	"f6934029a341ddf81dceb753e91d17efe16664f40d9f4ed84bc5ea87e111f29d",
+	"90facafea9b1556698540f70c0117a22ea37bd5cf3ed3c47093c1707282b4b89",
 	"747ae2dd2003664aeeb21e4753fe7402846170a16bc8df8f23a8cf06d3cbe793",
 	"f63838e96077ad1fc01c3f8405774dedc0641f558ebb4b40dccf5f9b6d66a932",
 	"0fc478f8579325fcee0d4cbc6d9d1ce21730a6e97e435d6008fb379b0ebe47d4",

--- a/jws.go
+++ b/jws.go
@@ -150,12 +150,13 @@ func parseSignedFull(input string) (*JSONWebSignature, error) {
 
 // sanitized produces a cleaned-up JWS object from the raw JSON.
 func (parsed *rawJSONWebSignature) sanitized() (*JSONWebSignature, error) {
-	if parsed.Payload == nil {
-		return nil, fmt.Errorf("square/go-jose: missing payload in JWS message")
+	var parsedPayload []byte
+	if parsed.Payload != nil {
+		parsedPayload = parsed.Payload.bytes()
 	}
 
 	obj := &JSONWebSignature{
-		payload:    parsed.Payload.bytes(),
+		payload:    parsedPayload,
 		Signatures: make([]Signature, len(parsed.Signatures)),
 	}
 


### PR DESCRIPTION
Hi Square,

According to JWS spec one can produce payload-detached serializations in compact _and_ JSON format, but jose currently does not allow me to parse a JSON document that does not have payload included.... In our scenario we will need the protected info before validation and having this would be convenient  ....

 - asac

p.s.  Note: I realize taht tests are failing, but wanted to discuss approach first ....
