### PR TITLE
Handle JSONWebKey by value when making JWERecipient

### DIFF
--- a/crypter.go
+++ b/crypter.go
@@ -266,6 +266,10 @@ func makeJWERecipient(alg KeyAlgorithm, encryptionKey interface{}) (recipientKey
 		return newSymmetricRecipient(alg, encryptionKey)
 	case string:
 		return newSymmetricRecipient(alg, []byte(encryptionKey))
+	case JSONWebKey:
+		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
+		recipient.keyID = encryptionKey.KeyID
+		return recipient, err
 	case *JSONWebKey:
 		recipient, err := makeJWERecipient(alg, encryptionKey.Key)
 		recipient.keyID = encryptionKey.KeyID


### PR DESCRIPTION
See #360.

`JSONWebKey` as a key was not supported, but `*JSONWebKey` was. Simply added a new case to handle the value version. Tests still pass. 

The second issue mentioned in #360 was a misread. The recipient, which contains the `keyID`, is added directly to the encrypter in the default case.